### PR TITLE
fix: use commit SHA as image_tag so Terraform always redeploys

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,8 +61,10 @@ jobs:
         run: |
           docker tag applybot "${REGISTRY}/applybot:${IMAGE_TAG}"
           docker tag applybot "${REGISTRY}/applybot:latest"
+          docker tag applybot "${REGISTRY}/applybot:${GITHUB_SHA}"
           docker push "${REGISTRY}/applybot:${IMAGE_TAG}"
           docker push "${REGISTRY}/applybot:latest"
+          docker push "${REGISTRY}/applybot:${GITHUB_SHA}"
 
       - name: Write summary
         run: |

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,6 +11,10 @@ on:
         options:
           - plan
           - apply
+      image_tag:
+        description: "Docker image tag to deploy (defaults to current commit SHA)"
+        required: false
+        type: string
 
   push:
     branches: [main]
@@ -25,7 +29,7 @@ env:
   TF_VAR_db_password: ${{ secrets.TF_VAR_DB_PASSWORD }}
   TF_VAR_anthropic_api_key: ${{ secrets.TF_VAR_ANTHROPIC_API_KEY }}
   TF_VAR_serpapi_key: ${{ secrets.TF_VAR_SERPAPI_KEY }}
-  TF_VAR_image_tag: ${{ vars.IMAGE_TAG || 'latest' }}
+  TF_VAR_image_tag: ${{ github.event.inputs.image_tag || github.sha }}
 
 jobs:
   terraform:


### PR DESCRIPTION
## Problem
The \
ull_resource.image_tag_tracker\ trigger only fires when \image_tag\ changes, but it was always set to \'latest'\. So Terraform never detected a new image was available and never redeployed Cloud Run.

## Fix
- **Terraform workflow**: Use \github.sha\ (full commit SHA) as \TF_VAR_image_tag\ instead of \'latest'\. This changes on every commit, so the null_resource trigger always fires.
- **Docker workflow**: Also push a tag with the full \\\ alongside the short SHA and \latest\, so the image is always findable by full SHA.
- **workflow_dispatch**: Added optional \image_tag\ input for manual override.