### PR TITLE
fix: disable Cloud SQL deletion protection before destroy

### DIFF
--- a/infra/cloud_sql.tf
+++ b/infra/cloud_sql.tf
@@ -1,0 +1,24 @@
+resource "google_sql_database_instance" "main" {
+  name             = "applybot-db"
+  database_version = "POSTGRES_15"
+  region           = var.region
+
+  settings {
+    tier              = "db-f1-micro"
+    edition           = "ENTERPRISE"
+    availability_type = "ZONAL"
+
+    backup_configuration {
+      enabled                        = true
+      point_in_time_recovery_enabled = false
+    }
+
+    ip_configuration {
+      ipv4_enabled = true
+    }
+  }
+
+  deletion_protection = false
+
+  depends_on = [google_project_service.services]
+}


### PR DESCRIPTION
Temporary fix: re-add Cloud SQL instance resource with deletion_protection=false so Terraform can update the live instance and allow deletion in the subsequent cleanup PR.