### PR TITLE
fix: avoid storage API permission failure in Terraform

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -29,7 +29,6 @@ provider "google" {
 resource "google_project_service" "services" {
   for_each = toset([
     "run.googleapis.com",
-    "storage.googleapis.com",
     "artifactregistry.googleapis.com",
     "secretmanager.googleapis.com",
     "cloudbuild.googleapis.com",


### PR DESCRIPTION
Removes storage.googleapis.com from terraform-managed project services. Current CI service account cannot enable that API, which was blocking apply after Cloud SQL cleanup.