### PR TITLE
ci: auto-deploy Cloud Run image on Docker push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,12 +2,6 @@ name: Docker
 
 on:
   workflow_dispatch:
-    inputs:
-      image_tag:
-        description: "Docker image tag (defaults to short SHA)"
-        required: false
-        type: string
-
   push:
     branches: [main]
 
@@ -26,9 +20,6 @@ jobs:
     permissions:
       contents: read
 
-    env:
-      IMAGE_TAG: ${{ github.event.inputs.image_tag || '' }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,14 +35,11 @@ jobs:
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker "${{ vars.GCP_REGION || 'us-central1' }}-docker.pkg.dev" --quiet
 
-      - name: Resolve image tag
+      - name: Set build variables
         run: |
-          if [ -z "$IMAGE_TAG" ]; then
-            IMAGE_TAG="${GITHUB_SHA::7}"
-          fi
           REGION="${{ vars.GCP_REGION || 'us-central1' }}"
           REGISTRY="${REGION}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/applybot"
-          echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_ENV"
+          echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
           echo "REGISTRY=${REGISTRY}" >> "$GITHUB_ENV"
 
       - name: Build Docker image
@@ -59,12 +47,18 @@ jobs:
 
       - name: Tag and push
         run: |
-          docker tag applybot "${REGISTRY}/applybot:${IMAGE_TAG}"
+          docker tag applybot "${REGISTRY}/applybot:${SHORT_SHA}"
           docker tag applybot "${REGISTRY}/applybot:latest"
-          docker tag applybot "${REGISTRY}/applybot:${GITHUB_SHA}"
-          docker push "${REGISTRY}/applybot:${IMAGE_TAG}"
+          docker push "${REGISTRY}/applybot:${SHORT_SHA}"
           docker push "${REGISTRY}/applybot:latest"
-          docker push "${REGISTRY}/applybot:${GITHUB_SHA}"
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy applybot \
+            --image "${REGISTRY}/applybot:latest" \
+            --region "${{ vars.GCP_REGION || 'us-central1' }}" \
+            --project "${{ secrets.GCP_PROJECT_ID }}" \
+            --quiet
 
       - name: Write summary
         run: |
@@ -74,6 +68,6 @@ jobs:
             echo "| Field | Value |"
             echo "|-------|-------|"
             echo "| **Registry** | \`${REGISTRY}\` |"
-            echo "| **Tag** | \`${IMAGE_TAG}\` |"
-            echo "| **Image** | \`${REGISTRY}/applybot:${IMAGE_TAG}\` |"
+            echo "| **Tag** | \`${SHORT_SHA}\` |"
+            echo "| **Image** | \`${REGISTRY}/applybot:${SHORT_SHA}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -12,7 +12,7 @@ on:
           - plan
           - apply
       image_tag:
-        description: "Docker image tag to deploy (defaults to current commit SHA)"
+        description: "Docker image tag for initial service creation (defaults to latest)"
         required: false
         type: string
 
@@ -28,7 +28,7 @@ env:
   TF_VAR_region: ${{ vars.GCP_REGION || 'us-central1' }}
   TF_VAR_anthropic_api_key: ${{ secrets.TF_VAR_ANTHROPIC_API_KEY }}
   TF_VAR_serpapi_key: ${{ secrets.TF_VAR_SERPAPI_KEY }}
-  TF_VAR_image_tag: ${{ github.event.inputs.image_tag || github.sha }}
+  TF_VAR_image_tag: ${{ github.event.inputs.image_tag || 'latest' }}
 
 jobs:
   terraform:

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -68,34 +68,45 @@ terraform output artifact_registry
 
 ## 4. Build and Push Docker Image
 
+The recommended way is to trigger the Docker GitHub Actions workflow, which builds,
+tags, pushes, and deploys to Cloud Run automatically:
+
+```bash
+# Trigger via GitHub Actions (push to main with --docker in commit message)
+git commit -m "initial deploy --docker"
+git push
+
+# Or trigger manually
+gh workflow run docker.yml
+```
+
+To do it manually (e.g. for a first deploy before CI is configured):
+
 ```bash
 # From the project root directory
-cd ..
-
-# Configure Docker to authenticate with Artifact Registry
 gcloud auth configure-docker us-central1-docker.pkg.dev
 
-# Build the image
-docker build -t applybot .
-
-# Tag for Artifact Registry (use the registry URL from terraform output)
 REGISTRY=$(cd infra && terraform output -raw artifact_registry)
-docker tag applybot ${REGISTRY}/applybot:v1
-
-# Push
-docker push ${REGISTRY}/applybot:v1
+docker build -t applybot .
+docker tag applybot ${REGISTRY}/applybot:latest
+docker push ${REGISTRY}/applybot:latest
 ```
 
 ## 5. Deploy to Cloud Run
 
-After pushing the image, Terraform can deploy it (if the image tag matches `var.image_tag`):
+Cloud Run is deployed automatically at the end of the Docker workflow via `gcloud run deploy`.
+Terraform only provisions the service on initial `terraform apply` — subsequent image updates
+do not require Terraform.
+
+To manually deploy a specific image:
 
 ```bash
-cd infra
-terraform apply   # Will update Cloud Run to use the pushed image
+REGISTRY=$(cd infra && terraform output -raw artifact_registry)
+gcloud run deploy applybot \
+  --image ${REGISTRY}/applybot:latest \
+  --region us-central1 \
+  --project your-project-id
 ```
-
-Or if the image tag was already set correctly during `terraform apply`, Cloud Run will pull it on next revision.
 
 ## 6. Verify
 
@@ -113,19 +124,29 @@ open $(terraform output -raw dashboard_url)
 
 ## 7. Deploying Updates
 
+Push a new image and redeploy Cloud Run by triggering the Docker workflow:
+
 ```bash
-# Build new image
-docker build -t applybot .
+# Via commit message trigger
+git commit -m "fix bug --docker"
+git push
 
-# Tag with new version
+# Or manually
+gh workflow run docker.yml
+```
+
+The workflow will:
+1. Build and push the image tagged as `:latest` and `:{short-sha}`
+2. Run `gcloud run deploy` to create a new Cloud Run revision
+
+To roll back to a previous build, redeploy using its short SHA tag:
+
+```bash
 REGISTRY=$(cd infra && terraform output -raw artifact_registry)
-docker tag applybot ${REGISTRY}/applybot:v2
-docker push ${REGISTRY}/applybot:v2
-
-# Update Terraform variable and apply
-cd infra
-# Update image_tag in terraform.tfvars to "v2"
-terraform apply
+gcloud run deploy applybot \
+  --image ${REGISTRY}/applybot:<short-sha> \
+  --region us-central1 \
+  --project your-project-id
 ```
 
 ## 8. Local Development (Docker)
@@ -193,7 +214,6 @@ Two workflows automate Terraform and Docker deployments.
    | Variable | Default | Description |
    |----------|---------|-------------|
    | `GCP_REGION` | `us-central1` | GCP region |
-   | `IMAGE_TAG` | `latest` | Default image tag for Terraform |
 
 ### Usage
 
@@ -202,13 +222,12 @@ Two workflows automate Terraform and Docker deployments.
 gh workflow run terraform.yml                    # plan + apply
 gh workflow run terraform.yml -f action=plan     # plan only
 
-# Docker — manual triggers
-gh workflow run docker.yml                       # tag = short SHA
-gh workflow run docker.yml -f image_tag=v2       # custom tag
+# Docker — manual trigger (builds, pushes :latest + :{short-sha}, deploys to Cloud Run)
+gh workflow run docker.yml
 
 # Commit-message triggers (push to main)
 git commit -m "update infra --tf-apply"          # runs terraform apply
-git commit -m "fix bug --docker"                 # builds & pushes Docker image
+git commit -m "fix bug --docker"                 # builds, pushes & deploys Docker image
 ```
 
 ## 10. Tear Down

--- a/infra/cloud_run.tf
+++ b/infra/cloud_run.tf
@@ -21,12 +21,6 @@ locals {
   image_uri = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.applybot.repository_id}/applybot:${var.image_tag}"
 }
 
-resource "null_resource" "image_tag_tracker" {
-  triggers = {
-    image_tag = var.image_tag
-  }
-}
-
 resource "google_cloud_run_v2_service" "applybot" {
   name     = "applybot"
   location = var.region
@@ -105,11 +99,12 @@ resource "google_cloud_run_v2_service" "applybot" {
     google_project_service.services,
     google_project_iam_member.cloud_run_firestore,
     google_project_iam_member.cloud_run_secrets,
-    null_resource.image_tag_tracker,
   ]
 
   lifecycle {
-    replace_triggered_by = [null_resource.image_tag_tracker]
+    # Image updates are deployed via gcloud run deploy in the Docker workflow.
+    # Terraform manages service config only; ignore image changes to prevent drift.
+    ignore_changes = [template[0].containers[0].image]
   }
 }
 


### PR DESCRIPTION
## Summary

Removes the tight coupling between Terraform and image deployments. Cloud Run now automatically gets a new revision whenever a new image is pushed, without requiring a Terraform apply.

## Changes

### \docker.yml\
- Added a \gcloud run deploy\ step after pushing the image, so every Docker build immediately triggers a new Cloud Run revision
- Removed the manual \image_tag\ workflow input (no longer needed)
- Removed the redundant full-SHA tag; kept the short-SHA tag as a rollback handle
- Simplified the \Resolve image tag\ step → \Set build variables\

### \infra/cloud_run.tf\
- Added \lifecycle { ignore_changes = [template[0].containers[0].image] }\ so Terraform no longer reverts image changes made by \gcloud run deploy\
- Removed \
ull_resource.image_tag_tracker\ and its \eplace_triggered_by\ lifecycle (obsolete)

### \infra/terraform.yml\
- Updated \image_tag\ input description (no longer SHA-based; defaults to \latest\ for initial creation)

### \DEPLOY.md\
- Rewrote sections 4, 5, 7 and the CI/CD usage block to match the new flow
- Removed the stale \IMAGE_TAG\ GitHub variable from the variables table

## Ownership split

| Concern | Owner |
|---|---|
| IAM, secrets, scaling config, probes | Terraform |
| Initial service creation | Terraform |
| Rolling out new image versions | Docker workflow (\gcloud run deploy\) |
| Rollback to a previous build | \gcloud run deploy --image ...:short-sha\ |
