### PR TITLE
feat: rework job list UI and fix EU scraper descriptions

### DIFF
--- a/src/applybot/dashboard/pages/jobs.py
+++ b/src/applybot/dashboard/pages/jobs.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from fasthtml.common import H1, A, P, Strong
+from fasthtml.common import H1, H4, A, Article, Div, P, Small, Strong
 
 from applybot.dashboard.components import (
     action_buttons,
     alert,
     collapsible_text,
     confirmed_card,
-    detail_card,
     filter_form,
     page,
     status_badge,
@@ -24,41 +23,46 @@ def _job_status_options(current: str) -> list[tuple[str, str]]:
 
 
 def _build_job_card(job: Job) -> object:
-    score = (
-        f"Score: {job.relevance_score:.0f}"
-        if job.relevance_score is not None
-        else "Score: N/A"
-    )
-    header = f"{job.title} at {job.company} -- {score}"
+    score = f"{job.relevance_score:.0f}" if job.relevance_score is not None else "N/A"
+    source_str = job.source.value if hasattr(job.source, "value") else str(job.source)
+    status_str = job.status.value if hasattr(job.status, "value") else str(job.status)
 
-    content = [
-        P(
-            Strong("Location: "),
-            job.location,
-            " | ",
-            Strong("Source: "),
-            job.source.value if hasattr(job.source, "value") else str(job.source),
-            " | ",
-            Strong("Status: "),
-            status_badge(
-                job.status.value if hasattr(job.status, "value") else str(job.status)
-            ),
+    header = Div(
+        Div(
+            H4(f"{job.title} at {job.company}", style="margin:0"),
+            Small(f"Score: {score} · {job.location} · {source_str}"),
+            style="flex:1",
         ),
-    ]
+        Div(status_badge(status_str), style="align-self:center;margin-left:1rem"),
+        style="display:flex;align-items:flex-start;gap:0.5rem",
+    )
+
+    meta_parts: list[object] = []
     if job.relevance_reasoning:
-        content.append(P(Strong("Match reasoning: "), job.relevance_reasoning))
+        meta_parts.append(P(Strong("Match: "), job.relevance_reasoning))
     if job.url:
-        content.append(P(A("View Job Posting", href=job.url, target="_blank")))
-    if job.description:
-        content.append(collapsible_text("Description", job.description[:2000]))
+        meta_parts.append(P(A("View Job Posting ↗", href=job.url, target="_blank")))
+
+    actions: list[object] = []
     if job.status == JobStatus.NEW:
-        content.append(
+        actions.append(
             action_buttons(
                 ("Approve", f"/jobs/{job.id}/approve", f"#job-{job.id}", ""),
                 ("Skip", f"/jobs/{job.id}/skip", f"#job-{job.id}", "secondary"),
             )
         )
-    return detail_card("job", job.id, header, *content)
+
+    desc_section: list[object] = []
+    if job.description:
+        desc_section.append(collapsible_text("Description", job.description[:2000]))
+
+    return Article(
+        header,
+        *meta_parts,
+        *actions,
+        *desc_section,
+        id=f"job-{job.id}",
+    )
 
 
 def register(rt: Any) -> None:

--- a/src/applybot/discovery/scrapers/euremotejobs.py
+++ b/src/applybot/discovery/scrapers/euremotejobs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import httpx
@@ -12,6 +13,20 @@ from applybot.discovery.scrapers.base import BaseScraper, RawJob
 logger = logging.getLogger(__name__)
 
 BASE_URL = "https://euremotejobs.com"
+
+# CSS selectors tried in order to find the job description on individual pages
+_DESCRIPTION_SELECTORS = [
+    ".job-description",
+    ".description",
+    "[class*='job-description']",
+    "[class*='description']",
+    ".content",
+    ".job-content",
+    "[class*='content']",
+    "article .entry-content",
+    ".entry-content",
+    "main",
+]
 
 
 class EuRemoteJobsScraper(BaseScraper):
@@ -45,8 +60,38 @@ class EuRemoteJobsScraper(BaseScraper):
                 seen_urls.add(job.url)
                 unique.append(job)
 
-        logger.info("EuRemoteJobs: found %d jobs", len(unique))
-        return unique[:max_results]
+        unique = unique[:max_results]
+
+        # Fetch full descriptions concurrently
+        async with httpx.AsyncClient(timeout=20.0, follow_redirects=True) as client:
+            descriptions = await asyncio.gather(
+                *[self._fetch_description(client, job.url) for job in unique],
+                return_exceptions=True,
+            )
+        enriched: list[RawJob] = []
+        for job, desc in zip(unique, descriptions):
+            if isinstance(desc, str) and desc:
+                enriched.append(
+                    RawJob(
+                        title=job.title,
+                        company=job.company,
+                        location=job.location,
+                        description=desc,
+                        url=job.url,
+                        source=job.source,
+                        posted_date=job.posted_date,
+                        extra=job.extra,
+                    )
+                )
+            else:
+                if isinstance(desc, Exception):
+                    logger.debug(
+                        "Failed to fetch description for %s: %s", job.url, desc
+                    )
+                enriched.append(job)
+
+        logger.info("EuRemoteJobs: found %d jobs", len(enriched))
+        return enriched
 
     async def _search_query(
         self,
@@ -110,8 +155,29 @@ class EuRemoteJobsScraper(BaseScraper):
             title=title,
             company=company,
             location=location,
-            description="",  # Would need to fetch individual page for full description
+            description="",
             url=url,
             source=self.source_name,
             posted_date=None,
         )
+
+    async def _fetch_description(self, client: httpx.AsyncClient, url: str) -> str:
+        """Fetch an individual job posting page and extract its description text."""
+        resp = await client.get(url)
+        resp.raise_for_status()
+        tree = lxml_html.fromstring(resp.text)
+
+        for selector in _DESCRIPTION_SELECTORS:
+            els = tree.cssselect(selector)
+            if els:
+                text: str = els[0].text_content().strip()
+                if (
+                    len(text) > 100
+                ):  # sanity check — real description should be substantial
+                    return text
+
+        # Last resort: dump all visible body text
+        body = tree.cssselect("body")
+        if body:
+            return str(body[0].text_content().strip())
+        return ""


### PR DESCRIPTION
## Summary

Two related fixes to improve the job queue experience.

### 1. `/jobs` page — always-visible job cards

Previously all job info was hidden inside a `<details>` dropdown. Now each job renders as a plain card with everything visible at a glance:

- Title, company, relevance score, location, and source in the header
- Status badge aligned to the right
- Match reasoning and a link to the job posting inline
- **Approve / Skip buttons immediately visible** for `new` jobs (no clicking to expand)
- Description still collapsible at the bottom when present

### 2. EU Jobs scraper — fetch full job descriptions

The scraper was leaving `description=""` for all jobs, so nothing appeared in Firestore or the dashboard dropdown. Now:

- After collecting the listing page results, the scraper **concurrently fetches each individual job posting URL** via `asyncio.gather`
- Tries a prioritised list of CSS selectors (`job-description`, `description`, `entry-content`, `main`, etc.) to extract meaningful text
- Falls back to full body text if no specific element matches
- Failed fetches are logged at DEBUG level; the job is still saved (with empty description) rather than dropped

### Tests

All 23 existing tests pass. All pre-commit hooks (black, ruff, mypy) pass.