### PR TITLE
feat: add PDF and Markdown resume upload support to profile dashboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pydantic>=2.10.0",
     "pydantic-settings>=2.7.0",
     "python-docx>=1.1.0",
+    "pypdf>=4.0.0",
     "httpx>=0.28.0",
     "lxml>=5.0.0",
     "cssselect>=1.2.0",

--- a/src/applybot/dashboard/README.md
+++ b/src/applybot/dashboard/README.md
@@ -45,12 +45,12 @@ The frontend uses a modular architecture:
 3. **Applications** (`/apps`) — Applications by status with cover letter, answers, and review actions
 4. **Profile** (`/profile`) — Full profile editor with multiple sections:
    - **Basic Info**: Edit name, email, summary
-   - **Resume upload**: Upload .docx, auto-parsed with `parse_resume()`, saved to `data/resume.docx`, backfills empty name/summary; resume sections are mapped to profile fields by keyword matching via `_map_resume_to_profile()`
+   - **Resume upload**: Upload `.docx`, `.pdf`, or `.md` files — auto-parsed with `parse_resume()`, saved to `data/resume.<ext>` (preserving the uploaded format), backfills empty name/summary; resume sections are mapped to profile fields by keyword matching via `_map_resume_to_profile()`. **Parsing is heuristic-only (no LLM).** PDF support requires a text-based PDF (scanned PDFs won't work).
    - **Skills / Experience / Education / Preferences**: Structured display + collapsible edit forms (`Details`/`Summary`) with JSON textarea editors and schema placeholder examples
    - **Raw JSON**: Collapsible full profile JSON view
    - **Flash messages**: Success/error alerts after each action
    - **Completeness indicator**: N/8 progress bar showing how many profile fields are filled
-   - **Resume download**: `GET /profile/resume` — serves `data/resume.docx` directly as a file download
+   - **Resume download**: `GET /profile/resume` — serves the uploaded resume file (format preserved: `.docx`, `.pdf`, or `.md`) as a file download
 
    Routes: `GET /profile`, `POST /profile` (basic info), `GET /profile/resume` (download), `POST /profile/resume` (upload), `POST /profile/details` (skills/experiences/education/preferences)
 

--- a/src/applybot/dashboard/pages/profile.py
+++ b/src/applybot/dashboard/pages/profile.py
@@ -35,12 +35,20 @@ logger = logging.getLogger(__name__)
 
 _MAX_RESUME_SIZE = 10 * 1024 * 1024  # 10 MB
 
+_ALLOWED_EXTENSIONS = {".docx", ".pdf", ".md"}
+
+_MIME_TYPES = {
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".pdf": "application/pdf",
+    ".md": "text/markdown",
+}
+
 _FLASH_MESSAGES: dict[str, tuple[str, str]] = {
     "basic_saved": ("Basic profile info saved.", "success"),
     "resume_uploaded": ("Resume uploaded and parsed successfully.", "success"),
     "details_saved": ("Profile details saved.", "success"),
     "no_file": ("No file selected.", "error"),
-    "invalid_docx": ("Please upload a .docx file.", "error"),
+    "invalid_file_type": ("Please upload a .docx, .pdf, or .md file.", "error"),
     "file_too_large": ("Resume file is too large (max 10 MB).", "error"),
     "no_resume": ("No resume file found.", "error"),
     "parse_failed": ("Failed to parse resume.", "error"),
@@ -129,8 +137,7 @@ def _map_resume_to_profile(parsed: ResumeData, profile: UserProfile) -> None:
             for kw in ("experience", "employment", "work history", "career")
         ):
             new_entries = [
-                {"section": section.heading, "details": item}
-                for item in section.items
+                {"section": section.heading, "details": item} for item in section.items
             ]
             if profile.experiences is None:
                 profile.experiences = new_entries
@@ -141,8 +148,7 @@ def _map_resume_to_profile(parsed: ResumeData, profile: UserProfile) -> None:
             for kw in ("education", "academic", "degree", "university", "school")
         ):
             new_entries = [
-                {"section": section.heading, "details": item}
-                for item in section.items
+                {"section": section.heading, "details": item} for item in section.items
             ]
             if profile.education is None:
                 profile.education = new_entries
@@ -269,8 +275,8 @@ def register(rt: Any) -> None:  # noqa: C901
             resume_display,
             Form(
                 Label(
-                    "Upload .docx resume",
-                    Input(type="file", name="resume", accept=".docx"),
+                    "Upload resume (.docx, .pdf, or .md)",
+                    Input(type="file", name="resume", accept=".docx,.pdf,.md"),
                 ),
                 Button("Upload & Parse Resume", type="submit"),
                 method="post",
@@ -417,13 +423,25 @@ def register(rt: Any) -> None:  # noqa: C901
 
     @rt("/profile/resume")
     def get_resume() -> Response:
-        dest = Path("data") / "resume.docx"
-        if not dest.exists():
+        profile = get_profile()
+        resume_path = (
+            Path(profile.resume_path) if profile and profile.resume_path else None
+        )
+        if resume_path is None or not resume_path.exists():
+            # Fall back to legacy hardcoded path for backwards compatibility
+            for ext in _ALLOWED_EXTENSIONS:
+                candidate = Path("data") / f"resume{ext}"
+                if candidate.exists():
+                    resume_path = candidate
+                    break
+        if resume_path is None or not resume_path.exists():
             return RedirectResponse("/profile?error=no_resume", status_code=303)
+        ext = resume_path.suffix.lower()
+        media_type = _MIME_TYPES.get(ext, "application/octet-stream")
         return FileResponse(
-            str(dest),
-            media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            filename="resume.docx",
+            str(resume_path),
+            media_type=media_type,
+            filename=resume_path.name,
         )
 
     @rt("/profile/resume")
@@ -434,8 +452,9 @@ def register(rt: Any) -> None:  # noqa: C901
             return RedirectResponse("/profile?error=no_file", status_code=303)
 
         filename: str = getattr(upload, "filename", "") or ""
-        if not filename.lower().endswith(".docx"):
-            return RedirectResponse("/profile?error=invalid_docx", status_code=303)
+        ext = Path(filename).suffix.lower()
+        if ext not in _ALLOWED_EXTENSIONS:
+            return RedirectResponse("/profile?error=invalid_file_type", status_code=303)
 
         content: bytes = await upload.read(_MAX_RESUME_SIZE + 1)
         if not content:
@@ -445,7 +464,7 @@ def register(rt: Any) -> None:  # noqa: C901
 
         data_dir = Path("data")
         data_dir.mkdir(parents=True, exist_ok=True)
-        dest = data_dir / "resume.docx"
+        dest = data_dir / f"resume{ext}"
         dest.write_bytes(content)
 
         try:

--- a/src/applybot/profile/README.md
+++ b/src/applybot/profile/README.md
@@ -1,11 +1,11 @@
 # Profile
 
-Manages the user's profile (structured data about skills, experiences, interests) and .docx resume parsing/generation. This is the central source of truth that Discovery and Application components consult.
+Manages the user's profile (structured data about skills, experiences, interests) and resume parsing/generation. This is the central source of truth that Discovery and Application components consult.
 
 ## Files
 
 - **manager.py** — `ProfileManager` for CRUD operations and JSON import/export
-- **resume.py** — Parse .docx resumes into structured data and generate tailored .docx files
+- **resume.py** — Parse resumes into structured data and generate tailored .docx files
 
 ## Public API
 
@@ -30,20 +30,39 @@ pm.import_profile_json(Path("profile.json"))       # Load from file
 ```python
 from applybot.profile.resume import parse_resume, generate_resume, ResumeData
 
+# Accepts .docx, .pdf, or .md files — dispatched by extension
 data: ResumeData = parse_resume(Path("resume.docx"))
-# ResumeData contains: name, contact_info, sections: list[ResumeSection]
-# ResumeSection contains: title, content: list[str]
+data: ResumeData = parse_resume(Path("resume.pdf"))
+data: ResumeData = parse_resume(Path("resume.md"))
+
+# ResumeData contains: name, contact_info, summary, sections: list[ResumeSection]
+# ResumeSection contains: heading, items: list[str]
 
 output: Path = generate_resume(data, template_path, output_path)
 # Creates a .docx preserving template formatting with tailored content
 ```
 
+#### Parsing approach (heuristic, no LLM)
+
+Parsing is purely heuristic — no LLM is involved. Each format uses text extraction and keyword/heading matching:
+
+| Format | Extractor | Heading detection |
+|--------|-----------|-------------------|
+| `.docx` | `python-docx` | Word heading styles or short bold paragraphs |
+| `.pdf`  | `pypdf` text layer | ALL-CAPS lines or known section keywords |
+| `.md`   | Built-in text read | ATX headings (`#`, `##`, `###`) |
+
+> ⚠️ PDF parsing only works on text-based PDFs. Scanned/image PDFs will yield poor results since there is no text layer to extract.
+
+Sections are mapped to profile fields via `_map_resume_to_profile()` in `dashboard/pages/profile.py` by keyword matching: headings containing "skill/technologies/tools" → `skills`, "experience/employment/work history/career" → `experiences`, "education/academic/degree/university/school" → `education`.
+
 ### CLI Bootstrap
 
 ```bash
-# Import a .docx resume and populate the database profile
+# Import a resume and populate the database profile (.docx, .pdf, or .md)
 applybot bootstrap-profile path/to/resume.docx
-applybot bootstrap-profile resume.docx --name "Jane Doe" --email jane@example.com
+applybot bootstrap-profile resume.pdf --name "Jane Doe" --email jane@example.com
+applybot bootstrap-profile resume.md
 ```
 
 Parses the resume, extracts name/summary/skills/experiences/education sections, and stores them in the database via ProfileManager.
@@ -55,5 +74,4 @@ Parses the resume, extracts name/summary/skills/experiences/education sections, 
 - **Used by**: Discovery (query building, relevance ranking), Application (resume tailoring, Q&A), Dashboard (profile display/edit)
 - ProfileManager owns all DB access for the UserProfile table
 - Resume functions are pure file I/O — no database or LLM calls
-- `parse_resume()` is called by the dashboard's `POST /profile/resume` endpoint to parse uploaded .docx files and backfill profile fields (name, summary)
-- `_map_resume_to_profile()` in `dashboard/pages/profile.py` maps parsed resume sections to profile fields by keyword matching: headings containing "skill/technologies/tools" → `skills`, "experience/employment/work history/career" → `experiences`, "education/academic/degree/university/school" → `education`
+- `parse_resume()` is called by the dashboard's `POST /profile/resume` endpoint to parse uploaded files and backfill profile fields (name, summary)

--- a/src/applybot/profile/resume.py
+++ b/src/applybot/profile/resume.py
@@ -1,8 +1,20 @@
-"""Resume manager — parse and generate .docx resumes."""
+"""Resume manager — parse and generate .docx resumes.
+
+Supported input formats for parse_resume():
+  - .docx  — heuristic paragraph/heading extractor using python-docx
+  - .pdf   — text-layer extraction via pypdf (does not work for scanned PDFs)
+  - .md    — Markdown heading-based section extractor
+
+The upload workflow is heuristic-based (no LLM). Sections are inferred by
+keyword matching on heading text (see _map_resume_to_profile in
+dashboard/pages/profile.py). For richer extraction, an LLM post-processing
+step could be added in future.
+"""
 
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -75,6 +87,25 @@ def _is_heading(paragraph: Paragraph) -> bool:
 
 
 def parse_resume(path: Path) -> ResumeData:
+    """Parse a resume file into structured ResumeData.
+
+    Dispatches to the appropriate parser based on file extension:
+    - .docx  — heuristic paragraph/heading extractor
+    - .pdf   — text-layer extraction (text-based PDFs only)
+    - .md    — Markdown heading-based extractor
+    """
+    ext = path.suffix.lower()
+    if ext == ".docx":
+        return _parse_resume_docx(path)
+    elif ext == ".pdf":
+        return _parse_resume_pdf(path)
+    elif ext == ".md":
+        return _parse_resume_md(path)
+    else:
+        raise ValueError(f"Unsupported resume format: {ext!r}. Use .docx, .pdf, or .md")
+
+
+def _parse_resume_docx(path: Path) -> ResumeData:
     """Parse a .docx resume into structured ResumeData.
 
     Heuristic approach:
@@ -115,7 +146,150 @@ def parse_resume(path: Path) -> ResumeData:
             else:
                 data.summary = text
 
-    logger.info("Parsed resume: %s, %d sections", data.name, len(data.sections))
+    logger.info("Parsed resume (docx): %s, %d sections", data.name, len(data.sections))
+    return data
+
+
+def _parse_resume_pdf(path: Path) -> ResumeData:
+    """Parse a text-based PDF resume into structured ResumeData.
+
+    Uses pypdf for text extraction. This does NOT work for scanned/image PDFs.
+    Text lines are processed with the same heuristics as the docx parser:
+    short ALL-CAPS or title-cased lines are treated as section headings.
+    """
+    try:
+        from pypdf import PdfReader
+    except ImportError as e:
+        raise ImportError(
+            "pypdf is required to parse PDF resumes: pip install pypdf"
+        ) from e
+
+    reader = PdfReader(str(path))
+    lines: list[str] = []
+    for page in reader.pages:
+        text = page.extract_text() or ""
+        lines.extend(text.splitlines())
+
+    data = ResumeData()
+    current_section: ResumeSection | None = None
+    found_name = False
+
+    for raw_line in lines:
+        text = raw_line.strip()
+        if not text:
+            continue
+
+        if not found_name:
+            data.name = text
+            found_name = True
+            continue
+
+        if (
+            not data.contact_info
+            and current_section is None
+            and not _is_pdf_heading(text)
+        ):
+            data.contact_info = text
+            continue
+
+        if _is_pdf_heading(text):
+            current_section = ResumeSection(heading=text)
+            data.sections.append(current_section)
+        elif current_section is not None:
+            current_section.items.append(text)
+        else:
+            if data.summary:
+                data.summary += "\n" + text
+            else:
+                data.summary = text
+
+    logger.info("Parsed resume (pdf): %s, %d sections", data.name, len(data.sections))
+    return data
+
+
+def _is_pdf_heading(text: str) -> bool:
+    """Heuristic: short ALL-CAPS lines or common resume section keywords are headings."""
+    if len(text) > 80:
+        return False
+    if text.isupper() and len(text) > 2:
+        return True
+    _heading_keywords = (
+        "experience",
+        "education",
+        "skills",
+        "summary",
+        "objective",
+        "projects",
+        "certifications",
+        "awards",
+        "publications",
+        "languages",
+        "interests",
+        "references",
+        "employment",
+        "work history",
+        "career",
+        "technologies",
+        "tools",
+    )
+    lower = text.lower()
+    return any(lower == kw or lower.startswith(kw + " ") for kw in _heading_keywords)
+
+
+def _parse_resume_md(path: Path) -> ResumeData:
+    """Parse a Markdown resume into structured ResumeData.
+
+    Sections are delimited by ATX headings (# / ## / ###).
+    The first heading or first non-empty line is treated as the name.
+    """
+    content = path.read_text(encoding="utf-8")
+    lines = content.splitlines()
+
+    data = ResumeData()
+    current_section: ResumeSection | None = None
+    found_name = False
+
+    for raw_line in lines:
+        text = raw_line.strip()
+        if not text:
+            continue
+
+        heading_match = re.match(r"^#{1,3}\s+(.*)", text)
+        if heading_match:
+            heading_text = heading_match.group(1).strip()
+            if not found_name:
+                data.name = heading_text
+                found_name = True
+            else:
+                current_section = ResumeSection(heading=heading_text)
+                data.sections.append(current_section)
+            continue
+
+        # Strip inline markdown (bold, italic, links, code)
+        clean = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)  # links
+        clean = re.sub(
+            r"[*_`]{1,2}([^*_`]+)[*_`]{1,2}", r"\1", clean
+        )  # bold/italic/code
+        clean = re.sub(r"^[-*+]\s+", "", clean)  # list bullets
+
+        if not found_name:
+            data.name = clean
+            found_name = True
+            continue
+
+        if not data.contact_info and current_section is None:
+            data.contact_info = clean
+            continue
+
+        if current_section is not None:
+            current_section.items.append(clean)
+        else:
+            if data.summary:
+                data.summary += "\n" + clean
+            else:
+                data.summary = clean
+
+    logger.info("Parsed resume (md): %s, %d sections", data.name, len(data.sections))
     return data
 
 


### PR DESCRIPTION
## Summary

Extends the `/profile` resume upload to accept `.pdf` and `.md` files in addition to `.docx`.

## Changes

### `src/applybot/profile/resume.py`
- `parse_resume()` now dispatches by file extension to one of three heuristic parsers
- `_parse_resume_docx()` — original logic, no behaviour change
- `_parse_resume_pdf()` — uses `pypdf` for text-layer extraction; headings detected by ALL-CAPS lines or known section keywords
- `_parse_resume_md()` — parses ATX headings (`#`/`##`/`###`) as section delimiters, strips inline markdown

### `src/applybot/dashboard/pages/profile.py`
- Form `accept` updated to `.docx,.pdf,.md`
- Validation now checks against `_ALLOWED_EXTENSIONS` set instead of hardcoded `.docx`
- Uploaded file saved as `data/resume.<ext>` (preserving original format)
- Download endpoint reads `profile.resume_path` for the correct file/MIME type (with fallback scan for legacy files)
- Flash message `invalid_docx` → `invalid_file_type` with updated text

### `pyproject.toml`
- Added `pypdf>=4.0.0`

### READMEs updated
- `src/applybot/profile/README.md`
- `src/applybot/dashboard/README.md`

## ⚠️ Important notes found during review

1. **Parsing is heuristic-only, not LLM-based.** The upload workflow does NOT use an LLM. It uses text extraction + keyword/heading matching to populate profile fields. The Profile and Dashboard components are explicitly designed to not depend on LLM. If LLM-based parsing is desired in the future, it would need to be added as an opt-in post-processing step.

2. **Scanned PDFs will not work.** `pypdf` only extracts the text layer. A scanned PDF (image-only) will produce empty or near-empty results. This is documented in the README and in the module docstring.

## Testing

All 23 existing tests pass. Ruff, black, and mypy all pass.
