### PR TITLE
feat(llm): add Gemini provider with ABC-based multi-provider architecture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,17 @@
 # LLM
-VERTEX_MODEL_FAST=claude-sonnet-4-6-20260301
-VERTEX_MODEL_SMART=claude-sonnet-4-6-20260301
-VERTEX_MAX_RETRIES=3
+LLM_PROVIDER=gemini                          # gemini (default) or anthropic
+
+# Both providers use Vertex AI — auth via Google ADC (GOOGLE_APPLICATION_CREDENTIALS)
 VERTEX_REGION=us-east5
+
+# Gemini (Vertex AI) — used when LLM_PROVIDER=gemini
+GEMINI_MODEL_FAST=gemini-2.0-flash
+GEMINI_MODEL_SMART=gemini-2.5-pro
+
+# Anthropic / Claude (Vertex AI) — used when LLM_PROVIDER=anthropic
+ANTHROPIC_MODEL_FAST=claude-sonnet-4-6
+ANTHROPIC_MODEL_SMART=claude-sonnet-4-6
+ANTHROPIC_MAX_RETRIES=3
 
 # Job scraping
 SERPAPI_KEY=...

--- a/README.md
+++ b/README.md
@@ -306,11 +306,15 @@ DISCOVERY_MAX_JOBS_PER_RUN=100
 # Application limits
 MAX_APPLICATIONS_PER_DAY=10
 
-# LLM models (Vertex AI)
-VERTEX_MODEL_FAST=claude-sonnet-4-6-20260301     # Cost-efficient tasks
-VERTEX_MODEL_SMART=claude-sonnet-4-6-20260301    # Complex reasoning
-VERTEX_MAX_RETRIES=3
-VERTEX_REGION=us-east5                           # Vertex AI region for Claude
+# LLM models
+LLM_PROVIDER=gemini                          # gemini (default) or anthropic
+VERTEX_REGION=us-east5                       # Vertex AI region (both providers)
+GEMINI_MODEL_FAST=gemini-2.0-flash           # Cost-efficient tasks
+GEMINI_MODEL_SMART=gemini-2.5-pro            # Complex reasoning
+# To switch to Claude on Vertex AI instead:
+# LLM_PROVIDER=anthropic
+# ANTHROPIC_MODEL_FAST=claude-sonnet-4-6
+# ANTHROPIC_MODEL_SMART=claude-sonnet-4-6
 ```
 
 ---

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -10,9 +10,9 @@ variable "region" {
 }
 
 variable "vertex_region" {
-  description = "Vertex AI region for Claude model access (use 'global' for the global endpoint, or a specific region like us-east5, europe-west1, asia-southeast1)"
+  description = "Vertex AI region for LLM access — used by both Gemini (google-genai SDK) and Anthropic Claude (anthropic Vertex SDK). Use a specific region like us-east5, us-central1, europe-west1."
   type        = string
-  default     = "global"
+  default     = "us-east5"
 }
 
 variable "serpapi_key" {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "AI-powered job application automation"
 requires-python = ">=3.12"
 dependencies = [
     "anthropic[vertex]>=0.40.0",
+    "google-genai>=1.0.0",
     "uvicorn>=0.32.0",
     "google-cloud-firestore>=2.19.0",
     "google-cloud-storage>=2.10.0",

--- a/src/applybot/application/question_answerer.py
+++ b/src/applybot/application/question_answerer.py
@@ -7,8 +7,7 @@ from dataclasses import dataclass
 
 from pydantic import BaseModel
 
-from applybot.config import settings
-from applybot.llm.client import llm
+from applybot.llm.client import get_llm
 from applybot.models.job import Job
 from applybot.models.profile import UserProfile
 
@@ -88,11 +87,11 @@ Provide answers as a JSON object with:
 - "missing_info": list of questions you couldn't fully answer due to missing profile information"""
 
     try:
-        result = llm.structured_output(
+        result = get_llm().structured_output(
             prompt,
             AnswerSet,
             system="You are an expert career coach helping with job applications. Be concise, professional, and truthful.",
-            model=settings.vertex_model_smart,
+            tier="smart",
             max_tokens=4096,
         )
 
@@ -145,10 +144,10 @@ CANDIDATE PROFILE:
 {profile_context}"""
 
     try:
-        return llm.complete(
+        return get_llm().complete(
             prompt,
             system="You are an expert career coach. Write authentic, specific cover letters.",
-            model=settings.vertex_model_smart,
+            tier="smart",
         )
     except Exception:
         logger.exception("Failed to generate cover letter for job %d", job.id)

--- a/src/applybot/application/resume_tailor.py
+++ b/src/applybot/application/resume_tailor.py
@@ -8,8 +8,7 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
-from applybot.config import settings
-from applybot.llm.client import llm
+from applybot.llm.client import get_llm
 from applybot.models.job import Job
 from applybot.models.profile import UserProfile
 from applybot.profile.resume import (
@@ -143,11 +142,11 @@ Create a tailoring plan:
 - sections: For each resume section, provide the items list with rephrased content emphasizing job-relevant keywords. Use the reorder field to specify which items should come first (by original index).
 - notes: Any observations about the match quality."""
 
-    return llm.structured_output(
+    return get_llm().structured_output(
         prompt,
         TailoringPlan,
         system="You are an expert resume writer. You tailor resumes to specific jobs while maintaining complete honesty. You NEVER fabricate information.",
-        model=settings.vertex_model_smart,
+        tier="smart",
         max_tokens=4096,
     )
 

--- a/src/applybot/config.py
+++ b/src/applybot/config.py
@@ -8,11 +8,19 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    # LLM (Vertex AI)
-    vertex_model_fast: str = "claude-sonnet-4-6"
-    vertex_model_smart: str = "claude-sonnet-4-6"
-    vertex_max_retries: int = 3
-    vertex_region: str = "us-east5"
+    # LLM provider — "gemini" (Google AI Studio) or "anthropic" (Vertex AI)
+    llm_provider: str = "gemini"
+
+    # Gemini (Google AI Studio) — set GEMINI_API_KEY for Cloud Run / local
+    gemini_model_fast: str = "gemini-2.0-flash"
+    gemini_model_smart: str = "gemini-2.5-pro"
+    gemini_api_key: str = ""
+
+    # Anthropic / Claude (Vertex AI) — kept for easy switching back
+    anthropic_model_fast: str = "claude-sonnet-4-6"
+    anthropic_model_smart: str = "claude-sonnet-4-6"
+    anthropic_max_retries: int = 3
+    anthropic_region: str = "us-east5"
 
     # Job scraping
     serpapi_key: str = ""

--- a/src/applybot/config.py
+++ b/src/applybot/config.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -8,19 +10,20 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    # LLM provider — "gemini" (Google AI Studio) or "anthropic" (Vertex AI)
-    llm_provider: str = "gemini"
+    # LLM provider — "gemini" (Vertex AI) or "anthropic" (Vertex AI)
+    llm_provider: Literal["gemini", "anthropic"] = "gemini"
 
-    # Gemini (Google AI Studio) — set GEMINI_API_KEY for Cloud Run / local
+    # Shared Vertex AI settings (both providers use Google ADC auth)
+    vertex_region: str = "us-east5"
+
+    # Gemini (Vertex AI)
     gemini_model_fast: str = "gemini-2.0-flash"
     gemini_model_smart: str = "gemini-2.5-pro"
-    gemini_api_key: str = ""
 
-    # Anthropic / Claude (Vertex AI) — kept for easy switching back
+    # Anthropic / Claude (Vertex AI)
     anthropic_model_fast: str = "claude-sonnet-4-6"
     anthropic_model_smart: str = "claude-sonnet-4-6"
     anthropic_max_retries: int = 3
-    anthropic_region: str = "us-east5"
 
     # Job scraping
     serpapi_key: str = ""

--- a/src/applybot/dashboard/README.md
+++ b/src/applybot/dashboard/README.md
@@ -107,6 +107,6 @@ The FastHTML app (`applybot serve`) is hosted on **GCP Cloud Run**:
 ### Secrets
 
 All sensitive config is stored in GCP Secret Manager and mounted as environment variables in Cloud Run:
-- `VERTEX_REGION`
+- `VERTEX_REGION` (Vertex AI region — used by both Gemini and Anthropic providers)
 - `SERPAPI_KEY`
 - `GOOGLE_APPLICATION_CREDENTIALS` (Gmail OAuth)

--- a/src/applybot/discovery/query_builder.py
+++ b/src/applybot/discovery/query_builder.py
@@ -6,7 +6,7 @@ import logging
 
 from pydantic import BaseModel
 
-from applybot.llm.client import llm
+from applybot.llm.client import get_llm
 from applybot.models.profile import UserProfile
 
 logger = logging.getLogger(__name__)
@@ -60,7 +60,7 @@ Profile:
 Return only the queries as a JSON object with a "queries" key containing a list of strings."""
 
     try:
-        result = llm.structured_output(
+        result = get_llm().structured_output(
             prompt,
             GeneratedQueries,
             system="You are a job search expert. Generate precise, effective search queries.",

--- a/src/applybot/discovery/ranker.py
+++ b/src/applybot/discovery/ranker.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 from applybot.config import settings
 from applybot.discovery.scrapers.base import RawJob
-from applybot.llm.client import llm
+from applybot.llm.client import get_llm
 from applybot.models.profile import UserProfile
 
 logger = logging.getLogger(__name__)
@@ -124,11 +124,10 @@ For each job, provide:
 
 Consider: skill match, experience relevance, seniority level, industry fit, location preferences."""
 
-    result = llm.structured_output(
+    result = get_llm().structured_output(
         prompt,
         BatchScoreResult,
         system="You are an expert recruiter matching candidates to jobs. Be calibrated: most jobs should score 30-70, only truly exceptional matches above 85.",
-        model=settings.vertex_model_fast,
     )
 
     scored: list[tuple[RawJob, int, str]] = []

--- a/src/applybot/discovery/tests/test_query_builder.py
+++ b/src/applybot/discovery/tests/test_query_builder.py
@@ -26,9 +26,9 @@ class TestBuildSearchQueries:
         # Should return all defaults, not crash
         assert len(result) == len(DEFAULT_QUERIES)
 
-    @patch("applybot.discovery.query_builder.llm")
-    def test_llm_generates_queries(self, mock_llm, mock_profile):
-        mock_llm.structured_output.return_value = GeneratedQueries(
+    @patch("applybot.discovery.query_builder.get_llm")
+    def test_llm_generates_queries(self, mock_get_llm, mock_profile):
+        mock_get_llm.return_value.structured_output.return_value = GeneratedQueries(
             queries=["robotics ML engineer", "perception engineer", "deep learning"]
         )
         result = build_search_queries(mock_profile, max_queries=3)
@@ -37,41 +37,47 @@ class TestBuildSearchQueries:
             "perception engineer",
             "deep learning",
         ]
-        mock_llm.structured_output.assert_called_once()
+        mock_get_llm.return_value.structured_output.assert_called_once()
 
-    @patch("applybot.discovery.query_builder.llm")
-    def test_llm_result_truncated_to_max_queries(self, mock_llm, mock_profile):
-        mock_llm.structured_output.return_value = GeneratedQueries(
+    @patch("applybot.discovery.query_builder.get_llm")
+    def test_llm_result_truncated_to_max_queries(self, mock_get_llm, mock_profile):
+        mock_get_llm.return_value.structured_output.return_value = GeneratedQueries(
             queries=["q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8"]
         )
         result = build_search_queries(mock_profile, max_queries=3)
         assert len(result) == 3
 
-    @patch("applybot.discovery.query_builder.llm")
-    def test_llm_failure_falls_back_to_defaults(self, mock_llm, mock_profile):
-        mock_llm.structured_output.side_effect = RuntimeError("API down")
+    @patch("applybot.discovery.query_builder.get_llm")
+    def test_llm_failure_falls_back_to_defaults(self, mock_get_llm, mock_profile):
+        mock_get_llm.return_value.structured_output.side_effect = RuntimeError(
+            "API down"
+        )
         result = build_search_queries(mock_profile)
         assert result == DEFAULT_QUERIES[:6]
 
-    @patch("applybot.discovery.query_builder.llm")
-    def test_prompt_includes_profile_info(self, mock_llm, mock_profile):
-        mock_llm.structured_output.return_value = GeneratedQueries(queries=["q1"])
+    @patch("applybot.discovery.query_builder.get_llm")
+    def test_prompt_includes_profile_info(self, mock_get_llm, mock_profile):
+        mock_get_llm.return_value.structured_output.return_value = GeneratedQueries(
+            queries=["q1"]
+        )
         build_search_queries(mock_profile, max_queries=1)
 
-        call_args = mock_llm.structured_output.call_args
+        call_args = mock_get_llm.return_value.structured_output.call_args
         prompt = call_args[0][0]  # First positional arg
         assert "Test User" in prompt or mock_profile.name in prompt
         assert "Python" in prompt or "skills" in prompt.lower()
 
-    @patch("applybot.discovery.query_builder.llm")
-    def test_profile_with_empty_skills(self, mock_llm):
+    @patch("applybot.discovery.query_builder.get_llm")
+    def test_profile_with_empty_skills(self, mock_get_llm):
         profile = MagicMock()
         profile.name = "Blank User"
         profile.summary = "Seeking ML roles"
         profile.skills = {}
         profile.experiences = []
         profile.preferences = {}
-        mock_llm.structured_output.return_value = GeneratedQueries(queries=["ml jobs"])
+        mock_get_llm.return_value.structured_output.return_value = GeneratedQueries(
+            queries=["ml jobs"]
+        )
 
         result = build_search_queries(profile, max_queries=2)
         assert len(result) >= 1

--- a/src/applybot/discovery/tests/test_ranker.py
+++ b/src/applybot/discovery/tests/test_ranker.py
@@ -117,15 +117,14 @@ class TestRankJobs:
 
 
 class TestScoreBatch:
-    @patch("applybot.discovery.ranker.llm")
+    @patch("applybot.discovery.ranker.get_llm")
     @patch("applybot.discovery.ranker.settings")
-    def test_scores_all_jobs_in_batch(self, mock_settings, mock_llm):
-        mock_settings.vertex_model_fast = "test-model"
+    def test_scores_all_jobs_in_batch(self, mock_settings, mock_get_llm):
         jobs = [
             make_raw_job(title="ML Engineer", url="https://a.com/1"),
             make_raw_job(title="Data Scientist", url="https://b.com/1"),
         ]
-        mock_llm.structured_output.return_value = BatchScoreResult(
+        mock_get_llm.return_value.structured_output.return_value = BatchScoreResult(
             scores=[
                 JobScore(job_index=0, score=85, reasoning="Strong ML match"),
                 JobScore(job_index=1, score=60, reasoning="Partial match"),
@@ -137,16 +136,15 @@ class TestScoreBatch:
         assert result[0][1] == 85
         assert result[1][1] == 60
 
-    @patch("applybot.discovery.ranker.llm")
+    @patch("applybot.discovery.ranker.get_llm")
     @patch("applybot.discovery.ranker.settings")
-    def test_missing_index_gets_neutral_score(self, mock_settings, mock_llm):
-        mock_settings.vertex_model_fast = "test-model"
+    def test_missing_index_gets_neutral_score(self, mock_settings, mock_get_llm):
         jobs = [
             make_raw_job(title="Job A", url="https://a.com/1"),
             make_raw_job(title="Job B", url="https://b.com/1"),
         ]
         # LLM only returns score for index 0, omits index 1
-        mock_llm.structured_output.return_value = BatchScoreResult(
+        mock_get_llm.return_value.structured_output.return_value = BatchScoreResult(
             scores=[JobScore(job_index=0, score=80, reasoning="Good")]
         )
 
@@ -156,12 +154,11 @@ class TestScoreBatch:
         assert scored_titles["Job A"] == 80
         assert scored_titles["Job B"] == 50  # Neutral fallback
 
-    @patch("applybot.discovery.ranker.llm")
+    @patch("applybot.discovery.ranker.get_llm")
     @patch("applybot.discovery.ranker.settings")
-    def test_out_of_range_index_ignored(self, mock_settings, mock_llm):
-        mock_settings.vertex_model_fast = "test-model"
+    def test_out_of_range_index_ignored(self, mock_settings, mock_get_llm):
         jobs = [make_raw_job(url="https://a.com/1")]
-        mock_llm.structured_output.return_value = BatchScoreResult(
+        mock_get_llm.return_value.structured_output.return_value = BatchScoreResult(
             scores=[
                 JobScore(job_index=0, score=80, reasoning="Good"),
                 JobScore(job_index=99, score=90, reasoning="Ghost job"),
@@ -172,18 +169,17 @@ class TestScoreBatch:
         assert len(result) == 1
         assert result[0][1] == 80
 
-    @patch("applybot.discovery.ranker.llm")
+    @patch("applybot.discovery.ranker.get_llm")
     @patch("applybot.discovery.ranker.settings")
-    def test_truncates_long_descriptions(self, mock_settings, mock_llm):
-        mock_settings.vertex_model_fast = "test-model"
+    def test_truncates_long_descriptions(self, mock_settings, mock_get_llm):
         long_desc = "x" * 5000
         jobs = [make_raw_job(description=long_desc, url="https://a.com/1")]
-        mock_llm.structured_output.return_value = BatchScoreResult(
+        mock_get_llm.return_value.structured_output.return_value = BatchScoreResult(
             scores=[JobScore(job_index=0, score=50, reasoning="Ok")]
         )
 
         _score_batch(jobs, "profile")
-        prompt = mock_llm.structured_output.call_args[0][0]
+        prompt = mock_get_llm.return_value.structured_output.call_args[0][0]
         # Description in prompt should be truncated to 1500 chars
         assert "x" * 1501 not in prompt
 

--- a/src/applybot/llm/README.md
+++ b/src/applybot/llm/README.md
@@ -48,8 +48,6 @@ Callers select model quality via the `tier` keyword argument (`"fast"` or `"smar
 - `ANTHROPIC_MODEL_FAST`, `ANTHROPIC_MODEL_SMART` — default `claude-sonnet-4-6`
 - `ANTHROPIC_MAX_RETRIES` — default `3`
 
-Pass `model=` to any method to override the default model for that call.
-
 ## Boundaries
 
 - **Depends on**: `config.py` (for provider selection and model settings)

--- a/src/applybot/llm/README.md
+++ b/src/applybot/llm/README.md
@@ -1,10 +1,10 @@
 # LLM
 
-Thin wrapper around the Anthropic Vertex AI SDK for all Claude API interactions. Provides three call patterns and a module-level singleton.
+Multi-provider LLM wrapper supporting Google Gemini and Anthropic Claude. Provides three call patterns and a module-level singleton.
 
 ## Files
 
-- **client.py** — `LLMClient` class and `llm` singleton instance
+- **client.py** — `LLMClient` abstract base class, `GeminiClient`, `AnthropicClient`, and `llm` singleton
 
 ## Public API
 
@@ -17,22 +17,37 @@ response: str = llm.complete(prompt, system="...", temperature=0.7)
 # Structured output parsed to a Pydantic model
 result: MyModel = llm.structured_output(prompt, output_type=MyModel, system="...")
 
-# Tool-use call (returns full Anthropic Message for tool call inspection)
-message: anthropic.types.Message = llm.with_tools(prompt, tools=[...], system="...")
+# Tool-use call — AnthropicClient only
+message = llm.with_tools(prompt, tools=[...], system="...")
 ```
 
 ### Configuration
 
-- Model selection via `settings.vertex_model_fast` / `settings.vertex_model_smart`
-- Pass `model=` to any method to override
-- Authentication via Google Application Default Credentials (ADC) — no API key needed
-- GCP project from `settings.gcp_project_id`
-- Vertex region from `settings.vertex_region` (default: `us-east5`)
-- Max retries: `settings.vertex_max_retries`
+The active backend is set by `settings.llm_provider` (env var `LLM_PROVIDER`):
+
+| Provider | Value | Auth |
+|---|---|---|
+| Google Gemini (default) | `"gemini"` | `GEMINI_API_KEY` env var |
+| Anthropic Claude on Vertex | `"anthropic"` | Google ADC (service account) |
+
+**Gemini settings** (env vars):
+- `LLM_PROVIDER=gemini` (default)
+- `GEMINI_API_KEY` — API key from [Google AI Studio](https://aistudio.google.com/app/apikey)
+- `GEMINI_MODEL_FAST` — default `gemini-2.0-flash`
+- `GEMINI_MODEL_SMART` — default `gemini-2.5-pro`
+- Uses the `google-genai` SDK (`google-genai>=1.0.0`)
+
+**Anthropic/Claude settings** (env vars):
+- `LLM_PROVIDER=anthropic`
+- `GCP_PROJECT_ID`, `ANTHROPIC_REGION` — Google Cloud project and Vertex AI region
+- `ANTHROPIC_MODEL_FAST`, `ANTHROPIC_MODEL_SMART` — default `claude-sonnet-4-6`
+- `ANTHROPIC_MAX_RETRIES` — default `3`
+
+Pass `model=` to any method to override the default model for that call.
 
 ## Boundaries
 
-- **Depends on**: `config.py` (for GCP project, region, and model settings)
+- **Depends on**: `config.py` (for provider selection and model settings)
 - **No knowledge of domain models** — this is a generic LLM utility
 - **Used by**: Query Builder, Ranker, Resume Tailor, Question Answerer, Gmail classifier
-- Consumers are responsible for prompt engineering and output parsing (except `structured_output` which handles JSON extraction)
+- `with_tools()` is only available with the `"anthropic"` provider

--- a/src/applybot/llm/README.md
+++ b/src/applybot/llm/README.md
@@ -4,21 +4,24 @@ Multi-provider LLM wrapper supporting Google Gemini and Anthropic Claude. Provid
 
 ## Files
 
-- **client.py** — `LLMClient` abstract base class, `GeminiClient`, `AnthropicClient`, and `llm` singleton
+- **client.py** — `LLMClient` abstract base class, `GeminiClient`, `AnthropicClient`, and `get_llm()` lazy singleton accessor
 
 ## Public API
 
 ```python
-from applybot.llm.client import llm
+from applybot.llm.client import get_llm
 
-# Simple text completion
-response: str = llm.complete(prompt, system="...", temperature=0.7)
+# Simple text completion (uses the fast model by default)
+response: str = get_llm().complete(prompt, system="...", temperature=0.7)
+
+# Use the smarter model for complex reasoning
+response: str = get_llm().complete(prompt, system="...", tier="smart")
 
 # Structured output parsed to a Pydantic model
-result: MyModel = llm.structured_output(prompt, output_type=MyModel, system="...")
+result: MyModel = get_llm().structured_output(prompt, output_type=MyModel, system="...", tier="smart")
 
 # Tool-use call — AnthropicClient only
-message = llm.with_tools(prompt, tools=[...], system="...")
+message = get_llm().with_tools(prompt, tools=[...], system="...")
 ```
 
 ### Configuration
@@ -27,19 +30,21 @@ The active backend is set by `settings.llm_provider` (env var `LLM_PROVIDER`):
 
 | Provider | Value | Auth |
 |---|---|---|
-| Google Gemini (default) | `"gemini"` | `GEMINI_API_KEY` env var |
+| Google Gemini (default) | `"gemini"` | Google ADC (service account) |
 | Anthropic Claude on Vertex | `"anthropic"` | Google ADC (service account) |
+
+Callers select model quality via the `tier` keyword argument (`"fast"` or `"smart"`, default `"fast"`). Each provider resolves the tier to its own configured model name — consumers never reference model strings directly.
 
 **Gemini settings** (env vars):
 - `LLM_PROVIDER=gemini` (default)
-- `GEMINI_API_KEY` — API key from [Google AI Studio](https://aistudio.google.com/app/apikey)
+- `GCP_PROJECT_ID`, `VERTEX_REGION` — Google Cloud project and Vertex AI region
 - `GEMINI_MODEL_FAST` — default `gemini-2.0-flash`
 - `GEMINI_MODEL_SMART` — default `gemini-2.5-pro`
-- Uses the `google-genai` SDK (`google-genai>=1.0.0`)
+- Uses the `google-genai` SDK (`google-genai>=1.0.0`) with Vertex AI
 
 **Anthropic/Claude settings** (env vars):
 - `LLM_PROVIDER=anthropic`
-- `GCP_PROJECT_ID`, `ANTHROPIC_REGION` — Google Cloud project and Vertex AI region
+- `GCP_PROJECT_ID`, `VERTEX_REGION` — Google Cloud project and Vertex AI region
 - `ANTHROPIC_MODEL_FAST`, `ANTHROPIC_MODEL_SMART` — default `claude-sonnet-4-6`
 - `ANTHROPIC_MAX_RETRIES` — default `3`
 

--- a/src/applybot/llm/client.py
+++ b/src/applybot/llm/client.py
@@ -1,12 +1,9 @@
-import logging
 from abc import ABC, abstractmethod
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 from pydantic import BaseModel
 
 from applybot.config import settings
-
-logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -15,7 +12,7 @@ class LLMClient(ABC):
     """Abstract base class for LLM provider backends.
 
     Concrete implementations: ``GeminiClient``, ``AnthropicClient``.
-    Use the module-level ``llm`` singleton rather than instantiating directly —
+    Use ``get_llm()`` rather than instantiating directly —
     the provider is selected via ``settings.llm_provider``.
     """
 
@@ -25,7 +22,7 @@ class LLMClient(ABC):
         prompt: str,
         *,
         system: str = "",
-        model: str | None = None,
+        tier: Literal["fast", "smart"] = "fast",
         max_tokens: int = 4096,
         temperature: float = 0.0,
     ) -> str:
@@ -38,7 +35,7 @@ class LLMClient(ABC):
         output_type: type[T],
         *,
         system: str = "",
-        model: str | None = None,
+        tier: Literal["fast", "smart"] = "fast",
         max_tokens: int = 4096,
     ) -> T:
         """Return a response parsed into a Pydantic model."""
@@ -49,7 +46,7 @@ class LLMClient(ABC):
         tools: list[dict[str, Any]],
         *,
         system: str = "",
-        model: str | None = None,
+        tier: Literal["fast", "smart"] = "fast",
         max_tokens: int = 4096,
     ) -> Any:
         """Send a message with tool definitions and return the raw response.
@@ -63,26 +60,37 @@ class LLMClient(ABC):
 
 
 class GeminiClient(LLMClient):
-    """Gemini backend via the ``google-genai`` SDK (API key auth)."""
+    """Gemini backend via the ``google-genai`` SDK (Vertex AI auth)."""
 
     def __init__(self) -> None:
         from google import genai
         from google.genai import types
 
-        self._client = genai.Client(api_key=settings.gemini_api_key)
+        self._client = genai.Client(
+            vertexai=True,
+            project=settings.gcp_project_id,
+            location=settings.vertex_region,
+        )
         self._types = types
+
+    def _model(self, tier: Literal["fast", "smart"]) -> str:
+        return (
+            settings.gemini_model_smart
+            if tier == "smart"
+            else settings.gemini_model_fast
+        )
 
     def complete(
         self,
         prompt: str,
         *,
         system: str = "",
-        model: str | None = None,
+        tier: Literal["fast", "smart"] = "fast",
         max_tokens: int = 4096,
         temperature: float = 0.0,
     ) -> str:
         response = self._client.models.generate_content(
-            model=model or settings.gemini_model_fast,
+            model=self._model(tier),
             contents=prompt,
             config=self._types.GenerateContentConfig(
                 system_instruction=system if system else None,
@@ -98,11 +106,11 @@ class GeminiClient(LLMClient):
         output_type: type[T],
         *,
         system: str = "",
-        model: str | None = None,
+        tier: Literal["fast", "smart"] = "fast",
         max_tokens: int = 4096,
     ) -> T:
         response = self._client.models.generate_content(
-            model=model or settings.gemini_model_fast,
+            model=self._model(tier),
             contents=prompt,
             config=self._types.GenerateContentConfig(
                 system_instruction=system if system else None,
@@ -122,8 +130,15 @@ class AnthropicClient(LLMClient):
 
         self._client = AnthropicVertex(
             project_id=settings.gcp_project_id,
-            region=settings.anthropic_region,
+            region=settings.vertex_region,
             max_retries=settings.anthropic_max_retries,
+        )
+
+    def _model(self, tier: Literal["fast", "smart"]) -> str:
+        return (
+            settings.anthropic_model_smart
+            if tier == "smart"
+            else settings.anthropic_model_fast
         )
 
     def complete(
@@ -131,12 +146,12 @@ class AnthropicClient(LLMClient):
         prompt: str,
         *,
         system: str = "",
-        model: str | None = None,
+        tier: Literal["fast", "smart"] = "fast",
         max_tokens: int = 4096,
         temperature: float = 0.0,
     ) -> str:
         kwargs: dict[str, Any] = {
-            "model": model or settings.anthropic_model_fast,
+            "model": self._model(tier),
             "max_tokens": max_tokens,
             "temperature": temperature,
             "messages": [{"role": "user", "content": prompt}],
@@ -152,12 +167,12 @@ class AnthropicClient(LLMClient):
         output_type: type[T],
         *,
         system: str = "",
-        model: str | None = None,
+        tier: Literal["fast", "smart"] = "fast",
         max_tokens: int = 4096,
     ) -> T:
         tool_name = "structured_output"
         kwargs: dict[str, Any] = {
-            "model": model or settings.anthropic_model_fast,
+            "model": self._model(tier),
             "max_tokens": max_tokens,
             "messages": [{"role": "user", "content": prompt}],
             "tools": [
@@ -189,11 +204,11 @@ class AnthropicClient(LLMClient):
         tools: list[dict[str, Any]],
         *,
         system: str = "",
-        model: str | None = None,
+        tier: Literal["fast", "smart"] = "fast",
         max_tokens: int = 4096,
     ) -> Any:
         kwargs: dict[str, Any] = {
-            "model": model or settings.anthropic_model_fast,
+            "model": self._model(tier),
             "max_tokens": max_tokens,
             "messages": [{"role": "user", "content": prompt}],
             "tools": tools,
@@ -206,12 +221,15 @@ class AnthropicClient(LLMClient):
 def _create_client() -> LLMClient:
     if settings.llm_provider == "gemini":
         return GeminiClient()
-    if settings.llm_provider == "anthropic":
-        return AnthropicClient()
-    raise ValueError(
-        f"Unknown llm_provider {settings.llm_provider!r}. Must be 'gemini' or 'anthropic'."
-    )
+    return AnthropicClient()
 
 
-# Module-level singleton for convenience
-llm: LLMClient = _create_client()
+_instance: LLMClient | None = None
+
+
+def get_llm() -> LLMClient:
+    """Return the shared LLMClient instance, creating it on first call."""
+    global _instance
+    if _instance is None:
+        _instance = _create_client()
+    return _instance

--- a/src/applybot/llm/client.py
+++ b/src/applybot/llm/client.py
@@ -98,6 +98,10 @@ class GeminiClient(LLMClient):
                 temperature=temperature,
             ),
         )
+        if response.text is None:
+            raise ValueError(
+                "Gemini returned no text — response may have been blocked by safety filters"
+            )
         return str(response.text)
 
     def structured_output(
@@ -119,6 +123,10 @@ class GeminiClient(LLMClient):
                 max_output_tokens=max_tokens,
             ),
         )
+        if response.text is None:
+            raise ValueError(
+                "Gemini returned no text — response may have been blocked by safety filters"
+            )
         return output_type.model_validate_json(str(response.text))
 
 
@@ -170,6 +178,10 @@ class AnthropicClient(LLMClient):
         tier: Literal["fast", "smart"] = "fast",
         max_tokens: int = 4096,
     ) -> T:
+        """Forces Claude to call a named tool whose input_schema matches the Pydantic
+        model, guaranteeing schema-valid JSON without prompt hacks or markdown-fence
+        stripping.
+        """
         tool_name = "structured_output"
         kwargs: dict[str, Any] = {
             "model": self._model(tier),

--- a/src/applybot/llm/client.py
+++ b/src/applybot/llm/client.py
@@ -1,8 +1,7 @@
 import logging
-from typing import Any, TypeVar, cast
+from abc import ABC, abstractmethod
+from typing import Any, TypeVar
 
-import anthropic
-from anthropic import AnthropicVertex
 from pydantic import BaseModel
 
 from applybot.config import settings
@@ -12,14 +11,119 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=BaseModel)
 
 
-class LLMClient:
-    """Thin wrapper around the Anthropic SDK with tool-use and structured output."""
+class LLMClient(ABC):
+    """Abstract base class for LLM provider backends.
+
+    Concrete implementations: ``GeminiClient``, ``AnthropicClient``.
+    Use the module-level ``llm`` singleton rather than instantiating directly —
+    the provider is selected via ``settings.llm_provider``.
+    """
+
+    @abstractmethod
+    def complete(
+        self,
+        prompt: str,
+        *,
+        system: str = "",
+        model: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+    ) -> str:
+        """Simple text completion — returns the assistant's text response."""
+
+    @abstractmethod
+    def structured_output(
+        self,
+        prompt: str,
+        output_type: type[T],
+        *,
+        system: str = "",
+        model: str | None = None,
+        max_tokens: int = 4096,
+    ) -> T:
+        """Return a response parsed into a Pydantic model."""
+
+    def with_tools(
+        self,
+        prompt: str,
+        tools: list[dict[str, Any]],
+        *,
+        system: str = "",
+        model: str | None = None,
+        max_tokens: int = 4096,
+    ) -> Any:
+        """Send a message with tool definitions and return the raw response.
+
+        Not supported by all providers — raises ``NotImplementedError`` by default.
+        Override in subclasses that support tool use (e.g. ``AnthropicClient``).
+        """
+        raise NotImplementedError(
+            f"with_tools() is not supported by {type(self).__name__}."
+        )
+
+
+class GeminiClient(LLMClient):
+    """Gemini backend via the ``google-genai`` SDK (API key auth)."""
 
     def __init__(self) -> None:
+        from google import genai
+        from google.genai import types
+
+        self._client = genai.Client(api_key=settings.gemini_api_key)
+        self._types = types
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        system: str = "",
+        model: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+    ) -> str:
+        response = self._client.models.generate_content(
+            model=model or settings.gemini_model_fast,
+            contents=prompt,
+            config=self._types.GenerateContentConfig(
+                system_instruction=system if system else None,
+                max_output_tokens=max_tokens,
+                temperature=temperature,
+            ),
+        )
+        return str(response.text)
+
+    def structured_output(
+        self,
+        prompt: str,
+        output_type: type[T],
+        *,
+        system: str = "",
+        model: str | None = None,
+        max_tokens: int = 4096,
+    ) -> T:
+        response = self._client.models.generate_content(
+            model=model or settings.gemini_model_fast,
+            contents=prompt,
+            config=self._types.GenerateContentConfig(
+                system_instruction=system if system else None,
+                response_mime_type="application/json",
+                response_schema=output_type,
+                max_output_tokens=max_tokens,
+            ),
+        )
+        return output_type.model_validate_json(str(response.text))
+
+
+class AnthropicClient(LLMClient):
+    """Anthropic Claude backend via the Vertex AI SDK (ADC auth)."""
+
+    def __init__(self) -> None:
+        from anthropic import AnthropicVertex
+
         self._client = AnthropicVertex(
             project_id=settings.gcp_project_id,
-            region=settings.vertex_region,
-            max_retries=settings.vertex_max_retries,
+            region=settings.anthropic_region,
+            max_retries=settings.anthropic_max_retries,
         )
 
     def complete(
@@ -31,19 +135,16 @@ class LLMClient:
         max_tokens: int = 4096,
         temperature: float = 0.0,
     ) -> str:
-        """Simple text completion — returns the assistant's text response."""
-        model = model or settings.vertex_model_fast
-        messages: list[dict[str, Any]] = [{"role": "user", "content": prompt}]
         kwargs: dict[str, Any] = {
-            "model": model,
+            "model": model or settings.anthropic_model_fast,
             "max_tokens": max_tokens,
             "temperature": temperature,
-            "messages": messages,
+            "messages": [{"role": "user", "content": prompt}],
         }
         if system:
             kwargs["system"] = system
-        response = self._client.messages.create(**kwargs)
-        return self._extract_text(response)
+        response: Any = self._client.messages.create(**kwargs)
+        return "\n".join(b.text for b in response.content if b.type == "text")
 
     def structured_output(
         self,
@@ -54,32 +155,24 @@ class LLMClient:
         model: str | None = None,
         max_tokens: int = 4096,
     ) -> T:
-        """Get a response parsed into a Pydantic model via forced tool use.
-
-        Forces Claude to call a tool whose input_schema matches the Pydantic
-        model, guaranteeing schema-valid JSON without any prompt hacks or
-        markdown-fence stripping.
-        """
-        model = model or settings.vertex_model_fast
         tool_name = "structured_output"
-        tools: list[dict[str, Any]] = [
-            {
-                "name": tool_name,
-                "description": f"Return a structured {output_type.__name__} object.",
-                "strict": True,
-                "input_schema": output_type.model_json_schema(),
-            }
-        ]
         kwargs: dict[str, Any] = {
-            "model": model,
+            "model": model or settings.anthropic_model_fast,
             "max_tokens": max_tokens,
             "messages": [{"role": "user", "content": prompt}],
-            "tools": tools,
+            "tools": [
+                {
+                    "name": tool_name,
+                    "description": f"Return a structured {output_type.__name__} object.",
+                    "strict": True,
+                    "input_schema": output_type.model_json_schema(),
+                }
+            ],
             "tool_choice": {"type": "tool", "name": tool_name},
         }
         if system:
             kwargs["system"] = system
-        response = cast(anthropic.types.Message, self._client.messages.create(**kwargs))
+        response: Any = self._client.messages.create(**kwargs)
 
         tool_use_block = next(
             (b for b in response.content if b.type == "tool_use"), None
@@ -88,7 +181,6 @@ class LLMClient:
             raise ValueError(
                 f"structured_output: expected a tool_use block in response, got: {response.content}"
             )
-
         return output_type.model_validate(tool_use_block.input)
 
     def with_tools(
@@ -99,28 +191,27 @@ class LLMClient:
         system: str = "",
         model: str | None = None,
         max_tokens: int = 4096,
-    ) -> anthropic.types.Message:
-        """Send a message with tool definitions, returning the full Message
-        so callers can inspect tool_use blocks and continue the conversation."""
-        model = model or settings.vertex_model_fast
+    ) -> Any:
         kwargs: dict[str, Any] = {
-            "model": model,
+            "model": model or settings.anthropic_model_fast,
             "max_tokens": max_tokens,
             "messages": [{"role": "user", "content": prompt}],
             "tools": tools,
         }
         if system:
             kwargs["system"] = system
-        return cast(anthropic.types.Message, self._client.messages.create(**kwargs))
+        return self._client.messages.create(**kwargs)
 
-    @staticmethod
-    def _extract_text(response: anthropic.types.Message) -> str:
-        parts: list[str] = []
-        for block in response.content:
-            if block.type == "text":
-                parts.append(block.text)
-        return "\n".join(parts)
+
+def _create_client() -> LLMClient:
+    if settings.llm_provider == "gemini":
+        return GeminiClient()
+    if settings.llm_provider == "anthropic":
+        return AnthropicClient()
+    raise ValueError(
+        f"Unknown llm_provider {settings.llm_provider!r}. Must be 'gemini' or 'anthropic'."
+    )
 
 
 # Module-level singleton for convenience
-llm = LLMClient()
+llm: LLMClient = _create_client()

--- a/src/applybot/profile/README.md
+++ b/src/applybot/profile/README.md
@@ -80,7 +80,7 @@ updated: UserProfile = enrich_profile_with_llm(profile, resume_text)
 asyncio.create_task(enrich_profile_with_llm_async(profile, resume_text))
 ```
 
-The LLM is instructed to preserve existing data and only add or improve. It uses `vertex_model_smart` from settings. If enrichment fails, the heuristic-parsed profile written earlier remains in Firestore, and a persistent `enrichment_warning` field is set on the profile so the dashboard can show the user an explicit warning.
+The LLM is instructed to preserve existing data and only add or improve. It calls `get_llm()` with `tier="smart"`, routing to the configured provider's smart model. If enrichment fails, the heuristic-parsed profile written earlier remains in Firestore, and a persistent `enrichment_warning` field is set on the profile so the dashboard can show the user an explicit warning.
 
 ### CLI Bootstrap
 

--- a/src/applybot/profile/enrichment.py
+++ b/src/applybot/profile/enrichment.py
@@ -12,8 +12,7 @@ import asyncio
 import logging
 from pathlib import Path
 
-from applybot.config import settings
-from applybot.llm.client import llm
+from applybot.llm.client import get_llm
 from applybot.models.profile import UserProfile, save_profile, update_profile_fields
 
 logger = logging.getLogger(__name__)
@@ -76,11 +75,11 @@ def enrich_profile_with_llm(profile: UserProfile, resume_text: str) -> UserProfi
         "Output the updated user profile. Keep 'id' and 'resume_path' exactly as-is."
     )
 
-    updated = llm.structured_output(
+    updated = get_llm().structured_output(
         prompt,
         UserProfile,
         system=_SYSTEM_PROMPT,
-        model=settings.vertex_model_smart,
+        tier="smart",
     )
 
     # Always preserve identity/path fields and guard against a missing name

--- a/src/applybot/tracking/gmail.py
+++ b/src/applybot/tracking/gmail.py
@@ -9,7 +9,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from applybot.config import settings
-from applybot.llm.client import llm
+from applybot.llm.client import get_llm
 from applybot.models.application import (
     ApplicationStatus,
     UpdateSource,
@@ -181,7 +181,7 @@ Determine:
 3. How confident are you? (0.0-1.0)"""
 
     try:
-        result = llm.structured_output(
+        result = get_llm().structured_output(
             prompt,
             EmailClassification,
             system="You classify job application emails. Be conservative — only classify with high confidence.",


### PR DESCRIPTION
## Summary

Replaces the hardcoded Anthropic/Claude Vertex AI usage with a pluggable LLM provider system. **Gemini on Vertex AI is now the default**; Claude can be switched in with a single env var change.

Both providers use **Google ADC (Application Default Credentials)** via Vertex AI — no API keys required.

## Changes

### Architecture

- `LLMClient` is now an ABC with abstract `complete` and `structured_output` methods
- `GeminiClient(LLMClient)`: uses `google-genai` SDK with Vertex AI auth (`vertexai=True`); `response_schema` handles structured output natively
- `AnthropicClient(LLMClient)`: preserves existing Claude Sonnet logic (tool-forcing pattern for structured output, `with_tools()` override)
- `get_llm()` lazy singleton accessor — replaces module-level `llm = LLMClient()` (avoids eager SDK import at module load time)
- `_create_client()` factory reads `LLM_PROVIDER` env var to select backend

### Model selection via `tier`

All `LLMClient` methods accept a `tier: Literal["fast", "smart"] = "fast"` keyword argument instead of a model name string. Each provider resolves the tier to its own configured model — consumers never reference model strings directly.

### Config (`config.py`)

New settings (all env-var driven):

- `LLM_PROVIDER` — `gemini` (default) or `anthropic`
- `VERTEX_REGION` — shared Vertex AI region for both providers (default `us-east5`)
- `GEMINI_MODEL_FAST` / `GEMINI_MODEL_SMART`
- `ANTHROPIC_MODEL_FAST` / `ANTHROPIC_MODEL_SMART` / `ANTHROPIC_MAX_RETRIES`

Removed: `GEMINI_API_KEY`, `ANTHROPIC_REGION` (replaced by shared `VERTEX_REGION`).
Renamed from PR v1: `VERTEX_MODEL_*` → provider-prefixed names; `llm_provider: Literal[...]` for type safety.

### Dependencies (`pyproject.toml`)

- Added `google-genai>=1.0.0`

### Infra (`infra/variables.tf`)

- Updated `vertex_region` description to cover both Gemini and Anthropic
- Changed default from `"global"` to `"us-east5"` (Gemini on Vertex requires a specific region)

### Docs

- `llm/README.md` — updated for `get_llm()`, `tier=`, both providers using Vertex AI ADC
- `profile/README.md`, `dashboard/README.md`, `README.md`, `.env.example` — updated env var references

## Switching between providers

```bash
# Use Gemini (default) — no extra vars needed beyond GCP_PROJECT_ID + VERTEX_REGION
LLM_PROVIDER=gemini

# Switch to Claude on Vertex AI
LLM_PROVIDER=anthropic
```

Both require `GOOGLE_APPLICATION_CREDENTIALS` pointing to a service account with Vertex AI access.
