### PR TITLE
chore: optimize Dockerfile — remove redundant src copy and exclude cloud function entry point

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,5 @@ infra/
 .github/
 *.md
 !README.md
+# Cloud Function entry point — not needed in the Cloud Run image
+main.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ WORKDIR /app
 COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
-# Copy application code
-COPY src/ src/
+# docker-entrypoint.sh is the only runtime file needed; applybot package is
+# already installed into site-packages via the builder stage above.
 COPY docker-entrypoint.sh .
 
 RUN chmod +x docker-entrypoint.sh


### PR DESCRIPTION
## Summary

Two small efficiency improvements to the Docker build:

### 1. Remove redundant `COPY src/ src/` in the final stage
The `pip install .` in the builder stage performs a non-editable install, copying the package into site-packages. The final stage already does `COPY --from=builder /usr/local/lib/python3.12/site-packages ...`, so the explicit `COPY src/ src/` was duplicating the source files unnecessarily. Removed.

### 2. Exclude `main.py` from the Docker build context (`.dockerignore`)
`main.py` is the Cloud Function entry point — it's not needed in the Cloud Run image. Added it to `.dockerignore` so it's never sent to the Docker daemon.
