### PR TITLE
feat(discovery): add LLM enrichment step to discovery pipeline

### DIFF
--- a/src/applybot/application/resume_tailor.py
+++ b/src/applybot/application/resume_tailor.py
@@ -120,7 +120,7 @@ def _get_tailoring_plan(
     prompt = f"""You are tailoring a resume for a specific job application.
 
 CRITICAL RULES:
-1. You may ONLY rephrase or reorder existing content from the resume and profile.
+1. You may ONLY use existing content from the resume and profile.
 2. You must NOT fabricate any experiences, skills, projects, or achievements.
 3. Emphasize the most relevant existing experiences and skills.
 4. Adjust wording to use keywords from the job description where truthful.

--- a/src/applybot/discovery/README.md
+++ b/src/applybot/discovery/README.md
@@ -1,6 +1,6 @@
 # Discovery
 
-Automated job search pipeline: generates queries from the user profile, scrapes multiple job boards in parallel, deduplicates results, ranks by relevance using Claude, and saves new jobs to the database.
+Automated job search pipeline: generates queries from the user profile, scrapes multiple job boards in parallel, deduplicates results, ranks by relevance using Claude, enriches each saved job with LLM-extracted fields, and saves new jobs to the database.
 
 ## Files
 
@@ -8,6 +8,7 @@ Automated job search pipeline: generates queries from the user profile, scrapes 
 - **query_builder.py** — `build_search_queries()` — LLM-powered query generation
 - **deduplicator.py** — `deduplicate()` — fuzzy matching + URL normalization
 - **ranker.py** — `rank_jobs()` — Claude batch-scoring (0-100)
+- **enricher.py** — `enrich_job()` — LLM verification and field extraction per job
 - **scrapers/** — pluggable scraper implementations
 
 ### Scrapers

--- a/src/applybot/discovery/enricher.py
+++ b/src/applybot/discovery/enricher.py
@@ -1,0 +1,100 @@
+"""LLM enrichment — verifies scraped job data and extracts structured fields."""
+
+from __future__ import annotations
+
+import logging
+
+from pydantic import BaseModel
+
+from applybot.discovery.scrapers.base import RawJob
+from applybot.llm.client import get_llm
+from applybot.models.job import Job
+
+logger = logging.getLogger(__name__)
+
+
+class JobEnrichment(BaseModel):
+    """LLM-verified and extracted fields for a job posting."""
+
+    title: str
+    """Corrected job title — use the scraped value if it is already accurate."""
+
+    company: str
+    """Corrected company name — use the scraped value if it is already accurate."""
+
+    location: str
+    """Corrected or clarified location — use the scraped value if it is already accurate."""
+
+    hard_requirements: list[str]
+    """Non-negotiable requirements explicitly stated in the posting.
+    Examples: 'US citizenship required', '5+ years of Python', 'PhD in Computer Science'.
+    Do NOT include preferred/nice-to-have qualifications."""
+
+    application_questions: list[str]
+    """Explicit questions the applicant must answer as part of the application.
+    Examples: 'Describe a time you led a team under pressure.',
+              'Why do you want to work at this company?'.
+    Only include questions explicitly directed at the applicant — not general job-description text."""
+
+
+_SYSTEM = (
+    "You are a meticulous recruiter parsing job postings. "
+    "Verify basic fields against the raw description and correct any scraping errors. "
+    "For hard_requirements, only include items explicitly marked as required or mandatory — "
+    "do not include preferred or nice-to-have items. "
+    "For application_questions, only include questions explicitly posed to the applicant in "
+    "the posting — not general text about the role."
+)
+
+
+def enrich_job(raw_job: RawJob, job: Job) -> Job:
+    """Use the LLM to verify scraped fields and extract hard requirements and application questions.
+
+    Sends the raw description and current job record to the LLM.
+    On success, updates title/company/location if the LLM finds corrections,
+    and populates hard_requirements and application_questions.
+    On failure, logs the error and returns the job unchanged.
+    """
+    desc = (raw_job.description or "(no description)")[:3000]
+
+    prompt = f"""Review this job posting and the record we scraped from it.
+
+SCRAPED JOB RECORD:
+  Title:    {job.title}
+  Company:  {job.company}
+  Location: {job.location}
+  URL:      {job.url}
+
+RAW JOB DESCRIPTION:
+{desc}
+
+Tasks:
+1. Verify title, company, and location are accurate. Correct them if the description contradicts what was scraped.
+2. Extract all hard/mandatory requirements (e.g. years of experience, certifications, citizenship, clearances).
+3. Extract any explicit application questions the candidate is asked to answer.
+
+Return the verified fields and all extracted data."""
+
+    try:
+        enrichment = get_llm().structured_output(
+            prompt,
+            JobEnrichment,
+            system=_SYSTEM,
+            tier="fast",
+        )
+        job.title = enrichment.title
+        job.company = enrichment.company
+        job.location = enrichment.location
+        job.hard_requirements = enrichment.hard_requirements
+        job.application_questions = enrichment.application_questions
+        logger.debug(
+            "Enriched '%s' @ %s: %d hard reqs, %d questions",
+            job.title,
+            job.company,
+            len(job.hard_requirements),
+            len(job.application_questions),
+        )
+    except Exception:
+        logger.exception("LLM enrichment failed for job '%s' (%s)", job.title, job.url)
+
+    return job

--- a/src/applybot/discovery/enricher.py
+++ b/src/applybot/discovery/enricher.py
@@ -82,9 +82,9 @@ Return the verified fields and all extracted data."""
             system=_SYSTEM,
             tier="fast",
         )
-        job.title = enrichment.title
-        job.company = enrichment.company
-        job.location = enrichment.location
+        job.title = enrichment.title.strip() or job.title
+        job.company = enrichment.company.strip() or job.company
+        job.location = enrichment.location.strip() or job.location
         job.hard_requirements = enrichment.hard_requirements
         job.application_questions = enrichment.application_questions
         logger.debug(

--- a/src/applybot/discovery/orchestrator.py
+++ b/src/applybot/discovery/orchestrator.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from applybot.config import settings
 from applybot.discovery.deduplicator import deduplicate
+from applybot.discovery.enricher import enrich_job
 from applybot.discovery.query_builder import build_search_queries
 from applybot.discovery.ranker import rank_jobs
 from applybot.discovery.scrapers.base import BaseScraper, RawJob
@@ -189,6 +190,7 @@ def _save_jobs(ranked: list[tuple[RawJob, int, str]]) -> int:
             relevance_reasoning=reasoning,
             status=JobStatus.NEW,
         )
+        job = enrich_job(raw_job, job)
         new_jobs.append(job)
         existing_urls.add(raw_job.url)
 

--- a/src/applybot/models/job.py
+++ b/src/applybot/models/job.py
@@ -46,6 +46,8 @@ class Job(BaseModel):
     relevance_score: float | None = None
     relevance_reasoning: str = ""
     status: JobStatus = JobStatus.NEW
+    hard_requirements: list[str] = Field(default_factory=list)
+    application_questions: list[str] = Field(default_factory=list)
 
     def __repr__(self) -> str:
         return f"<Job {self.id}: {self.title} @ {self.company}>"


### PR DESCRIPTION
## Summary

Adds a new LLM-powered enrichment step that runs after ranking in the discovery pipeline. For each saved job, the LLM verifies the scraped metadata and extracts structured fields that aren't available from most scrapers.

## Changes

### `discovery/enricher.py` (new)
- `enrich_job(raw_job, job)` — sends the raw description + scraped record to the LLM
- Verifies `title`, `company`, and `location` (corrects scraping errors)
- Extracts `hard_requirements` — non-negotiable requirements explicitly stated in the posting (e.g. citizenship, years of experience, clearance)
- Extracts `application_questions` — explicit questions the applicant must answer
- Uses `tier="fast"` since this runs per-job at save time
- Gracefully falls back (logs exception, returns job unchanged) on LLM failure

### `models/job.py`
- Add `hard_requirements: list[str]` and `application_questions: list[str]` fields to `Job`

### `discovery/orchestrator.py`
- Wire `enrich_job()` into `_save_jobs()` immediately after building each `Job` object

### `application/resume_tailor.py`
- Tighten prompt wording: _"rephrase or reorder existing content"_ → _"use existing content"_ to reduce hallucination risk

### `discovery/README.md`
- Document the new `enricher.py` file