### PR TITLE
feat: rich inline editing UI for applications page; remove DRAFT status

### DIFF
--- a/src/applybot/dashboard/pages/apps.py
+++ b/src/applybot/dashboard/pages/apps.py
@@ -24,6 +24,7 @@ from fasthtml.common import (
 from starlette.requests import Request
 from starlette.responses import Response
 
+from applybot.application.resume_tailor import tailor_resume
 from applybot.dashboard.components import (
     alert,
     confirmed_card,
@@ -41,6 +42,8 @@ from applybot.models.application import (
     update_application,
 )
 from applybot.models.job import Job, get_job
+from applybot.profile.manager import ProfileManager
+from applybot.storage import download_file
 from applybot.tracking.tracker import InvalidTransitionError, update_status
 
 _TERMINAL = {ApplicationStatus.REJECTED, ApplicationStatus.WITHDRAWN}
@@ -108,7 +111,6 @@ def _cover_letter_section(
                     hx_post=f"/apps/{app_id}/cover-letter",
                     hx_target=f"#cover-letter-section-{app_id}",
                     hx_swap="outerHTML",
-                    hx_include="closest form",
                     cls="qa-save-btn secondary",
                 ),
             ),
@@ -216,7 +218,6 @@ def _qa_section(
                     hx_post=f"/apps/{app_id}/answers",
                     hx_target=f"#qa-section-{app_id}",
                     hx_swap="outerHTML",
-                    hx_include="closest form",
                     cls="qa-save-btn secondary",
                 ),
             ),
@@ -368,8 +369,12 @@ def register(rt: Any) -> None:
         app = get_application(app_id)
         if app is None:
             return alert(f"Application {app_id} not found.", "error")
-        update_application(app_id, cover_letter=cover_letter)
-        return _cover_letter_section(app_id, cover_letter, saved=True)
+        is_terminal = app.status in _TERMINAL
+        if not is_terminal:
+            update_application(app_id, cover_letter=cover_letter)
+        return _cover_letter_section(
+            app_id, cover_letter, terminal=is_terminal, saved=not is_terminal
+        )
 
     # -- Q&A answers save -----------------------------------------------------
 
@@ -387,9 +392,11 @@ def register(rt: Any) -> None:
             if question:
                 answers[question] = answer
             i += 1
-        update_application(app_id, answers=answers)
-        app.answers = answers
-        return _qa_section(app, saved=True)
+        is_terminal = app.status in _TERMINAL
+        if not is_terminal:
+            update_application(app_id, answers=answers)
+            app.answers = answers
+        return _qa_section(app, terminal=is_terminal, saved=not is_terminal)
 
     # -- Resume re-tailor -----------------------------------------------------
 
@@ -398,13 +405,12 @@ def register(rt: Any) -> None:
         app = get_application(app_id)
         if app is None:
             return alert(f"Application {app_id} not found.", "error")
+        if app.status in _TERMINAL:
+            return alert("Cannot re-tailor a terminal application.", "error")
         job = get_job(app.job_id)
         if job is None:
             return alert(f"Job {app.job_id} not found for this application.", "error")
         try:
-            from applybot.application.resume_tailor import tailor_resume
-            from applybot.profile.manager import ProfileManager
-
             profile = ProfileManager().get_profile()
             if profile is None:
                 return alert("No profile found -- cannot re-tailor resume.", "error")
@@ -423,14 +429,15 @@ def register(rt: Any) -> None:
         if app is None or not app.tailored_resume_path:
             return alert("Resume not found.", "error")
         try:
-            from applybot.storage import download_file
-
             content = download_file(app.tailored_resume_path)
             filename = Path(app.tailored_resume_path).name
+            safe_filename = filename.replace('"', "").replace(";", "").replace("\\", "")
             return Response(
                 content=content,
                 media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+                headers={
+                    "Content-Disposition": f'attachment; filename="{safe_filename}"'
+                },
             )
         except Exception as exc:
             return alert(f"Download failed: {exc}", "error")

--- a/src/applybot/dashboard/pages/apps.py
+++ b/src/applybot/dashboard/pages/apps.py
@@ -1,15 +1,31 @@
-"""Applications page — list, filter, approve, return to draft."""
+"""Applications page — list, filter, approve, and rich inline editing."""
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
-from fasthtml.common import H1, Details, Div, Hr, P, Span, Strong, Summary
+from fasthtml.common import (
+    H1,
+    H4,
+    A,
+    Button,
+    Div,
+    Form,
+    Input,
+    Label,
+    P,
+    Pre,
+    Small,
+    Span,
+    Strong,
+    Textarea,
+)
+from starlette.requests import Request
+from starlette.responses import Response
 
 from applybot.dashboard.components import (
-    action_buttons,
     alert,
-    collapsible_text,
     confirmed_card,
     detail_card,
     filter_form,
@@ -20,10 +36,14 @@ from applybot.models.application import (
     Application,
     ApplicationStatus,
     UpdateSource,
+    get_application,
     query_applications,
+    update_application,
 )
 from applybot.models.job import Job, get_job
 from applybot.tracking.tracker import InvalidTransitionError, update_status
+
+_TERMINAL = {ApplicationStatus.REJECTED, ApplicationStatus.WITHDRAWN}
 
 
 def _app_status_options(current: str) -> list[tuple[str, str]]:
@@ -33,10 +53,10 @@ def _app_status_options(current: str) -> list[tuple[str, str]]:
 
 
 def _build_gap_section(gaps: list[dict[str, str]]) -> Div:
-    """Render a warning section for profile gaps on a READY_FOR_REVIEW application."""
+    """Render a warning section for profile gaps."""
     items = [
         Div(
-            Span("?", cls="gap-icon"),
+            Span("⚠", cls="gap-icon"),
             Div(
                 Div(g.get("question", ""), cls="gap-question"),
                 Div(g.get("context", ""), cls="gap-context"),
@@ -60,58 +80,229 @@ def _build_gap_section(gaps: list[dict[str, str]]) -> Div:
     )
 
 
-def _build_app_card(application: Application, job: Job | None) -> object:
-    job_label = f"{job.title} at {job.company}" if job else f"Job #{application.job_id}"
-    summary_text = (
-        f"{job_label} -- {application.status.value.replace('_', ' ').capitalize()}"
+# -- Cover-letter fragments ---------------------------------------------------
+
+
+def _cover_letter_display(app_id: str, cover_letter: str) -> Div:
+    """Cover-letter section in read mode."""
+    return Div(
+        H4("Cover Letter"),
+        Pre(cover_letter or "(none)", cls="cover-letter-pre"),
+        Button(
+            "Edit",
+            hx_get=f"/apps/{app_id}/cover-letter/edit",
+            hx_target=f"#cover-letter-section-{app_id}",
+            hx_swap="outerHTML",
+            cls="secondary outline",
+            style="margin-top:0.5rem",
+        ),
+        id=f"cover-letter-section-{app_id}",
+        cls="app-section",
     )
 
-    content = [
+
+def _cover_letter_edit(app_id: str, cover_letter: str) -> Div:
+    """Cover-letter section in edit (form) mode."""
+    return Div(
+        H4("Cover Letter"),
+        Form(
+            Textarea(
+                cover_letter or "",
+                name="cover_letter",
+                rows="14",
+                style="width:100%;font-family:'JetBrains Mono',monospace;font-size:0.85em;",
+            ),
+            Div(
+                Button(
+                    "Save",
+                    type="submit",
+                    hx_post=f"/apps/{app_id}/cover-letter",
+                    hx_target=f"#cover-letter-section-{app_id}",
+                    hx_swap="outerHTML",
+                    hx_include="closest form",
+                ),
+                Button(
+                    "Cancel",
+                    type="button",
+                    hx_get=f"/apps/{app_id}/cover-letter/view",
+                    hx_target=f"#cover-letter-section-{app_id}",
+                    hx_swap="outerHTML",
+                    cls="secondary outline",
+                ),
+                style="display:flex;gap:0.5rem;margin-top:0.5rem",
+            ),
+        ),
+        id=f"cover-letter-section-{app_id}",
+        cls="app-section",
+    )
+
+
+# -- Resume fragment ----------------------------------------------------------
+
+
+def _resume_section(app: Application) -> Div:
+    """Tailored-resume section fragment."""
+    app_id = app.id
+    retailor_btn = Button(
+        "Re-tailor Resume",
+        hx_post=f"/apps/{app_id}/retailor",
+        hx_target=f"#resume-section-{app_id}",
+        hx_swap="outerHTML",
+        hx_indicator=f"#retailor-ind-{app_id}",
+        cls="retailor-btn secondary",
+    )
+    indicator = Span(
+        "Working...",
+        id=f"retailor-ind-{app_id}",
+        cls="htmx-indicator",
+        style="font-size:0.8em;color:var(--text-2)",
+    )
+    if app.tailored_resume_path:
+        filename = Path(app.tailored_resume_path).name
+        body = Div(
+            A(filename, href=f"/apps/{app_id}/resume/download", cls="resume-download"),
+            retailor_btn,
+            indicator,
+            cls="resume-section",
+        )
+    else:
+        body = Div(
+            P(Small("No tailored resume generated."), style="margin:0"),
+            retailor_btn,
+            indicator,
+            cls="resume-section",
+        )
+    return Div(
+        H4("Tailored Resume"),
+        body,
+        id=f"resume-section-{app_id}",
+        cls="app-section",
+    )
+
+
+# -- Q&A fragment -------------------------------------------------------------
+
+
+def _qa_section(app: Application) -> Div:
+    """Q&A answers section fragment (always in edit mode)."""
+    app_id = app.id
+    if not app.answers:
+        return Div(
+            H4("Q&A Answers"),
+            P(Small("No questions for this application."), style="margin:0"),
+            id=f"qa-section-{app_id}",
+            cls="app-section",
+        )
+    items = []
+    for i, (question, answer) in enumerate(app.answers.items()):
+        items.append(
+            Div(
+                Input(type="hidden", name=f"q_{i}", value=question),
+                Label(question, _for=f"a_{i}"),
+                Textarea(answer or "", name=f"a_{i}", id=f"a_{i}", rows="3"),
+                cls="qa-item",
+            )
+        )
+    return Div(
+        H4("Q&A Answers"),
+        Form(
+            *items,
+            Div(
+                Button(
+                    "Save Answers",
+                    type="submit",
+                    hx_post=f"/apps/{app_id}/answers",
+                    hx_target=f"#qa-section-{app_id}",
+                    hx_swap="outerHTML",
+                    hx_include="closest form",
+                    cls="qa-save-btn secondary",
+                ),
+            ),
+        ),
+        id=f"qa-section-{app_id}",
+        cls="app-section",
+    )
+
+
+# -- Main card builder --------------------------------------------------------
+
+
+def _build_app_card(application: Application, job: Job | None) -> object:
+    app_id = application.id
+    job_title = job.title if job else "Unknown Job"
+    job_company = job.company if job else f"Job #{application.job_id}"
+    score = getattr(job, "relevance_score", None) if job else None
+
+    status_str = application.status.value.replace("_", " ").capitalize()
+    summary_text = f"{job_title} @ {job_company} -- {status_str}"
+    if score is not None:
+        summary_text += f"  |  Score {score:.0f}"
+
+    # Section: Details
+    details_items: list[object] = [
         P(
             Strong("Status: "),
             status_badge(application.status.value),
-            " | ",
+            "  ",
             Strong("Created: "),
             str(application.created_at)[:19] if application.created_at else "---",
-        ),
+        )
     ]
     if application.submitted_at:
-        content.append(P(Strong("Submitted: "), str(application.submitted_at)[:19]))
-
-    # Show profile gaps prominently on READY_FOR_REVIEW cards
+        details_items.append(
+            P(Strong("Submitted: "), str(application.submitted_at)[:19])
+        )
     if (
         application.profile_gaps
         and application.status == ApplicationStatus.READY_FOR_REVIEW
     ):
-        content.append(_build_gap_section(application.profile_gaps))
+        details_items.append(_build_gap_section(application.profile_gaps))
+    details_section = Div(H4("Details"), *details_items, cls="app-section")
 
-    if application.cover_letter:
-        content.append(collapsible_text("Cover Letter", application.cover_letter))
-    if application.answers:
-        qa_items = []
-        for q, a in application.answers.items():
-            qa_items.extend([P(Strong("Q: "), q), P("A: ", a), Hr()])
-        content.append(Details(Summary("Application Answers"), *qa_items))
-    if application.tailored_resume_path:
-        content.append(P(Strong("Tailored resume: "), application.tailored_resume_path))
+    # Section: Actions
+    action_items: list[object] = []
     if application.status == ApplicationStatus.READY_FOR_REVIEW:
-        content.append(
-            action_buttons(
-                (
-                    "Approve",
-                    f"/apps/{application.id}/approve",
-                    f"#app-{application.id}",
-                    "",
-                ),
-                (
-                    "Back to Draft",
-                    f"/apps/{application.id}/draft",
-                    f"#app-{application.id}",
-                    "secondary",
-                ),
+        action_items.append(
+            Button(
+                "Approve",
+                hx_post=f"/apps/{app_id}/approve",
+                hx_target=f"#app-{app_id}",
+                hx_swap="outerHTML",
             )
         )
-    return detail_card("app", application.id, summary_text, *content)
+    if application.status not in _TERMINAL:
+        action_items.append(
+            Button(
+                "Withdraw",
+                hx_post=f"/apps/{app_id}/withdraw",
+                hx_target=f"#app-{app_id}",
+                hx_swap="outerHTML",
+                cls="secondary outline",
+            )
+        )
+    actions_sec: object = (
+        Div(
+            H4("Actions"),
+            Div(*action_items, style="display:flex;gap:0.5rem;flex-wrap:wrap"),
+            cls="app-section",
+        )
+        if action_items
+        else None
+    )
+
+    sections: list[object] = [
+        details_section,
+        _resume_section(application),
+        _cover_letter_display(app_id, application.cover_letter),
+        _qa_section(application),
+    ]
+    if actions_sec is not None:
+        sections.append(actions_sec)
+
+    return detail_card("app", app_id, summary_text, *sections)
+
+
+# -- Route registration -------------------------------------------------------
 
 
 def register(rt: Any) -> None:
@@ -141,23 +332,116 @@ def register(rt: Any) -> None:
         cards = [_build_app_card(app, get_job(app.job_id)) for app in apps] or [
             alert("No applications found.")
         ]
-
         return page(H1("Applications"), form, count_text, *cards, title="Applications")
 
+    # -- Status transitions ---------------------------------------------------
+
     @rt("/apps/{app_id}/approve", methods=["post"])
-    def post(app_id: str) -> object:
+    def post_approve(app_id: str) -> object:
         try:
             update_status(app_id, ApplicationStatus.APPROVED, UpdateSource.MANUAL)
             return confirmed_card("app", app_id, f"Application #{app_id}", "Approved")
         except (ValueError, InvalidTransitionError) as e:
             return alert(str(e), "error")
 
-    @rt("/apps/{app_id}/draft", methods=["post"])
-    def post_draft(app_id: str) -> object:
+    @rt("/apps/{app_id}/withdraw", methods=["post"])
+    def post_withdraw(app_id: str) -> object:
         try:
-            update_status(app_id, ApplicationStatus.DRAFT, UpdateSource.MANUAL)
-            return confirmed_card(
-                "app", app_id, f"Application #{app_id}", "Back to Draft"
-            )
+            update_status(app_id, ApplicationStatus.WITHDRAWN, UpdateSource.MANUAL)
+            return confirmed_card("app", app_id, f"Application #{app_id}", "Withdrawn")
         except (ValueError, InvalidTransitionError) as e:
             return alert(str(e), "error")
+
+    # -- Cover-letter edit/save -----------------------------------------------
+
+    @rt("/apps/{app_id}/cover-letter/edit", methods=["get"])
+    def get_cover_letter_edit(app_id: str) -> object:
+        app = get_application(app_id)
+        if app is None:
+            return alert(f"Application {app_id} not found.", "error")
+        return _cover_letter_edit(app_id, app.cover_letter)
+
+    @rt("/apps/{app_id}/cover-letter/view", methods=["get"])
+    def get_cover_letter_view(app_id: str) -> object:
+        app = get_application(app_id)
+        if app is None:
+            return alert(f"Application {app_id} not found.", "error")
+        return _cover_letter_display(app_id, app.cover_letter)
+
+    @rt("/apps/{app_id}/cover-letter", methods=["post"])
+    def post_cover_letter(app_id: str, cover_letter: str = "") -> object:
+        app = get_application(app_id)
+        if app is None:
+            return alert(f"Application {app_id} not found.", "error")
+        update_application(app_id, cover_letter=cover_letter)
+        return _cover_letter_display(app_id, cover_letter)
+
+    # -- Q&A answers save -----------------------------------------------------
+
+    @rt("/apps/{app_id}/answers", methods=["post"])
+    async def post_answers(app_id: str, request: Request) -> object:
+        app = get_application(app_id)
+        if app is None:
+            return alert(f"Application {app_id} not found.", "error")
+        form = await request.form()
+        answers: dict[str, str] = {}
+        i = 0
+        while f"q_{i}" in form:
+            question = str(form[f"q_{i}"])
+            answer = str(form.get(f"a_{i}", ""))
+            if question:
+                answers[question] = answer
+            i += 1
+        update_application(app_id, answers=answers)
+        app.answers = answers
+        return Div(
+            _qa_section(app),
+            P(
+                "Answers saved.",
+                style="font-size:0.8em;color:#4ade80;margin:0.25rem 0 0",
+            ),
+        )
+
+    # -- Resume re-tailor -----------------------------------------------------
+
+    @rt("/apps/{app_id}/retailor", methods=["post"])
+    def post_retailor(app_id: str) -> object:
+        app = get_application(app_id)
+        if app is None:
+            return alert(f"Application {app_id} not found.", "error")
+        job = get_job(app.job_id)
+        if job is None:
+            return alert(f"Job {app.job_id} not found for this application.", "error")
+        try:
+            from applybot.application.resume_tailor import tailor_resume
+            from applybot.profile.manager import ProfileManager
+
+            profile = ProfileManager().get_profile()
+            if profile is None:
+                return alert("No profile found -- cannot re-tailor resume.", "error")
+            new_path = tailor_resume(job, profile)
+            update_application(app_id, tailored_resume_path=str(new_path))
+            app.tailored_resume_path = str(new_path)
+            return _resume_section(app)
+        except Exception as exc:
+            return alert(f"Re-tailor failed: {exc}", "error")
+
+    # -- Resume download ------------------------------------------------------
+
+    @rt("/apps/{app_id}/resume/download", methods=["get"])
+    def get_resume_download(app_id: str) -> object:
+        app = get_application(app_id)
+        if app is None or not app.tailored_resume_path:
+            return alert("Resume not found.", "error")
+        try:
+            from applybot.storage import download_file
+
+            content = download_file(app.tailored_resume_path)
+            filename = Path(app.tailored_resume_path).name
+            return Response(
+                content=content,
+                media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+            )
+        except Exception as exc:
+            return alert(f"Download failed: {exc}", "error")

--- a/src/applybot/dashboard/pages/apps.py
+++ b/src/applybot/dashboard/pages/apps.py
@@ -15,6 +15,7 @@ from fasthtml.common import (
     Input,
     Label,
     P,
+    Pre,
     Small,
     Span,
     Strong,
@@ -82,11 +83,18 @@ def _build_gap_section(gaps: list[dict[str, str]]) -> Div:
 # -- Cover-letter fragment ---------------------------------------------------
 
 
-def _cover_letter_section(app_id: str, cover_letter: str) -> Div:
-    """Cover-letter section — always editable, matching Q&A UX."""
-    return Div(
-        H4("Cover Letter"),
-        Form(
+def _cover_letter_section(
+    app_id: str, cover_letter: str, *, terminal: bool = False, saved: bool = False
+) -> Div:
+    """Cover-letter section — editable normally, read-only for terminal statuses."""
+    if terminal:
+        body: object = (
+            Pre(cover_letter, cls="cover-letter-pre")
+            if cover_letter
+            else P(Small("No cover letter."), style="margin:0")
+        )
+    else:
+        body = Form(
             Textarea(
                 cover_letter or "",
                 name="cover_letter",
@@ -104,45 +112,54 @@ def _cover_letter_section(app_id: str, cover_letter: str) -> Div:
                     cls="qa-save-btn secondary",
                 ),
             ),
-        ),
-        id=f"cover-letter-section-{app_id}",
-        cls="app-section",
-    )
+        )
+    children: list[object] = [H4("Cover Letter"), body]
+    if saved:
+        children.append(
+            P(
+                "Cover letter saved.",
+                style="font-size:0.8em;color:#4ade80;margin:0.25rem 0 0",
+            )
+        )
+    return Div(*children, id=f"cover-letter-section-{app_id}", cls="app-section")
 
 
 # -- Resume fragment ----------------------------------------------------------
 
 
-def _resume_section(app: Application) -> Div:
+def _resume_section(app: Application, *, terminal: bool = False) -> Div:
     """Tailored-resume section fragment."""
     app_id = app.id
-    retailor_btn = Button(
-        "Re-tailor Resume",
-        hx_post=f"/apps/{app_id}/retailor",
-        hx_target=f"#resume-section-{app_id}",
-        hx_swap="outerHTML",
-        hx_indicator=f"#retailor-ind-{app_id}",
-        cls="retailor-btn secondary",
-    )
-    indicator = Span(
-        "Working...",
-        id=f"retailor-ind-{app_id}",
-        cls="htmx-indicator",
-        style="font-size:0.8em;color:var(--text-2)",
-    )
+    if not terminal:
+        extra: list[object] = [
+            Button(
+                "Re-tailor Resume",
+                hx_post=f"/apps/{app_id}/retailor",
+                hx_target=f"#resume-section-{app_id}",
+                hx_swap="outerHTML",
+                hx_indicator=f"#retailor-ind-{app_id}",
+                cls="retailor-btn secondary",
+            ),
+            Span(
+                "Working...",
+                id=f"retailor-ind-{app_id}",
+                cls="htmx-indicator",
+                style="font-size:0.8em;color:var(--text-2)",
+            ),
+        ]
+    else:
+        extra = []
     if app.tailored_resume_path:
         filename = Path(app.tailored_resume_path).name
         body = Div(
             A(filename, href=f"/apps/{app_id}/resume/download", cls="resume-download"),
-            retailor_btn,
-            indicator,
+            *extra,
             cls="resume-section",
         )
     else:
         body = Div(
             P(Small("No tailored resume generated."), style="margin:0"),
-            retailor_btn,
-            indicator,
+            *extra,
             cls="resume-section",
         )
     return Div(
@@ -156,8 +173,10 @@ def _resume_section(app: Application) -> Div:
 # -- Q&A fragment -------------------------------------------------------------
 
 
-def _qa_section(app: Application) -> Div:
-    """Q&A answers section fragment (always in edit mode)."""
+def _qa_section(
+    app: Application, *, terminal: bool = False, saved: bool = False
+) -> Div:
+    """Q&A answers section fragment — editable normally, read-only for terminal statuses."""
     app_id = app.id
     if not app.answers:
         return Div(
@@ -166,20 +185,30 @@ def _qa_section(app: Application) -> Div:
             id=f"qa-section-{app_id}",
             cls="app-section",
         )
-    items = []
-    for i, (question, answer) in enumerate(app.answers.items()):
-        items.append(
-            Div(
-                Input(type="hidden", name=f"q_{i}", value=question),
-                Label(question, _for=f"a_{i}"),
-                Textarea(answer or "", name=f"a_{i}", id=f"a_{i}", rows="3"),
-                cls="qa-item",
-            )
+    if terminal:
+        body: object = Div(
+            *[
+                Div(
+                    Label(question),
+                    P(answer or "(no answer)", style="margin:0;font-size:0.9em;"),
+                    cls="qa-item",
+                )
+                for question, answer in app.answers.items()
+            ]
         )
-    return Div(
-        H4("Q&A Answers"),
-        Form(
-            *items,
+    else:
+        form_items = []
+        for i, (question, answer) in enumerate(app.answers.items()):
+            form_items.append(
+                Div(
+                    Input(type="hidden", name=f"q_{i}", value=question),
+                    Label(question, _for=f"a_{i}"),
+                    Textarea(answer or "", name=f"a_{i}", id=f"a_{i}", rows="3"),
+                    cls="qa-item",
+                )
+            )
+        body = Form(
+            *form_items,
             Div(
                 Button(
                     "Save Answers",
@@ -191,10 +220,16 @@ def _qa_section(app: Application) -> Div:
                     cls="qa-save-btn secondary",
                 ),
             ),
-        ),
-        id=f"qa-section-{app_id}",
-        cls="app-section",
-    )
+        )
+    children: list[object] = [H4("Q&A Answers"), body]
+    if saved:
+        children.append(
+            P(
+                "Answers saved.",
+                style="font-size:0.8em;color:#4ade80;margin:0.25rem 0 0",
+            )
+        )
+    return Div(*children, id=f"qa-section-{app_id}", cls="app-section")
 
 
 # -- Main card builder --------------------------------------------------------
@@ -263,11 +298,12 @@ def _build_app_card(application: Application, job: Job | None) -> object:
         else None
     )
 
+    is_terminal = application.status in _TERMINAL
     sections: list[object] = [
         details_section,
-        _resume_section(application),
-        _cover_letter_section(app_id, application.cover_letter),
-        _qa_section(application),
+        _resume_section(application, terminal=is_terminal),
+        _cover_letter_section(app_id, application.cover_letter, terminal=is_terminal),
+        _qa_section(application, terminal=is_terminal),
     ]
     if actions_sec is not None:
         sections.append(actions_sec)
@@ -333,13 +369,7 @@ def register(rt: Any) -> None:
         if app is None:
             return alert(f"Application {app_id} not found.", "error")
         update_application(app_id, cover_letter=cover_letter)
-        return Div(
-            _cover_letter_section(app_id, cover_letter),
-            P(
-                "Cover letter saved.",
-                style="font-size:0.8em;color:#4ade80;margin:0.25rem 0 0",
-            ),
-        )
+        return _cover_letter_section(app_id, cover_letter, saved=True)
 
     # -- Q&A answers save -----------------------------------------------------
 
@@ -359,13 +389,7 @@ def register(rt: Any) -> None:
             i += 1
         update_application(app_id, answers=answers)
         app.answers = answers
-        return Div(
-            _qa_section(app),
-            P(
-                "Answers saved.",
-                style="font-size:0.8em;color:#4ade80;margin:0.25rem 0 0",
-            ),
-        )
+        return _qa_section(app, saved=True)
 
     # -- Resume re-tailor -----------------------------------------------------
 

--- a/src/applybot/dashboard/pages/apps.py
+++ b/src/applybot/dashboard/pages/apps.py
@@ -15,7 +15,6 @@ from fasthtml.common import (
     Input,
     Label,
     P,
-    Pre,
     Small,
     Span,
     Strong,
@@ -80,29 +79,11 @@ def _build_gap_section(gaps: list[dict[str, str]]) -> Div:
     )
 
 
-# -- Cover-letter fragments ---------------------------------------------------
+# -- Cover-letter fragment ---------------------------------------------------
 
 
-def _cover_letter_display(app_id: str, cover_letter: str) -> Div:
-    """Cover-letter section in read mode."""
-    return Div(
-        H4("Cover Letter"),
-        Pre(cover_letter or "(none)", cls="cover-letter-pre"),
-        Button(
-            "Edit",
-            hx_get=f"/apps/{app_id}/cover-letter/edit",
-            hx_target=f"#cover-letter-section-{app_id}",
-            hx_swap="outerHTML",
-            cls="secondary outline",
-            style="margin-top:0.5rem",
-        ),
-        id=f"cover-letter-section-{app_id}",
-        cls="app-section",
-    )
-
-
-def _cover_letter_edit(app_id: str, cover_letter: str) -> Div:
-    """Cover-letter section in edit (form) mode."""
+def _cover_letter_section(app_id: str, cover_letter: str) -> Div:
+    """Cover-letter section — always editable, matching Q&A UX."""
     return Div(
         H4("Cover Letter"),
         Form(
@@ -114,22 +95,14 @@ def _cover_letter_edit(app_id: str, cover_letter: str) -> Div:
             ),
             Div(
                 Button(
-                    "Save",
+                    "Save Cover Letter",
                     type="submit",
                     hx_post=f"/apps/{app_id}/cover-letter",
                     hx_target=f"#cover-letter-section-{app_id}",
                     hx_swap="outerHTML",
                     hx_include="closest form",
+                    cls="qa-save-btn secondary",
                 ),
-                Button(
-                    "Cancel",
-                    type="button",
-                    hx_get=f"/apps/{app_id}/cover-letter/view",
-                    hx_target=f"#cover-letter-section-{app_id}",
-                    hx_swap="outerHTML",
-                    cls="secondary outline",
-                ),
-                style="display:flex;gap:0.5rem;margin-top:0.5rem",
             ),
         ),
         id=f"cover-letter-section-{app_id}",
@@ -293,7 +266,7 @@ def _build_app_card(application: Application, job: Job | None) -> object:
     sections: list[object] = [
         details_section,
         _resume_section(application),
-        _cover_letter_display(app_id, application.cover_letter),
+        _cover_letter_section(app_id, application.cover_letter),
         _qa_section(application),
     ]
     if actions_sec is not None:
@@ -352,21 +325,7 @@ def register(rt: Any) -> None:
         except (ValueError, InvalidTransitionError) as e:
             return alert(str(e), "error")
 
-    # -- Cover-letter edit/save -----------------------------------------------
-
-    @rt("/apps/{app_id}/cover-letter/edit", methods=["get"])
-    def get_cover_letter_edit(app_id: str) -> object:
-        app = get_application(app_id)
-        if app is None:
-            return alert(f"Application {app_id} not found.", "error")
-        return _cover_letter_edit(app_id, app.cover_letter)
-
-    @rt("/apps/{app_id}/cover-letter/view", methods=["get"])
-    def get_cover_letter_view(app_id: str) -> object:
-        app = get_application(app_id)
-        if app is None:
-            return alert(f"Application {app_id} not found.", "error")
-        return _cover_letter_display(app_id, app.cover_letter)
+    # -- Cover-letter save ----------------------------------------------------
 
     @rt("/apps/{app_id}/cover-letter", methods=["post"])
     def post_cover_letter(app_id: str, cover_letter: str = "") -> object:
@@ -374,7 +333,13 @@ def register(rt: Any) -> None:
         if app is None:
             return alert(f"Application {app_id} not found.", "error")
         update_application(app_id, cover_letter=cover_letter)
-        return _cover_letter_display(app_id, cover_letter)
+        return Div(
+            _cover_letter_section(app_id, cover_letter),
+            P(
+                "Cover letter saved.",
+                style="font-size:0.8em;color:#4ade80;margin:0.25rem 0 0",
+            ),
+        )
 
     # -- Q&A answers save -----------------------------------------------------
 

--- a/src/applybot/dashboard/theme.py
+++ b/src/applybot/dashboard/theme.py
@@ -847,6 +847,71 @@ nav a { position: relative; }
     display: block;
     margin-bottom: 0.75rem;
 }
+
+/* -- Application card sections --------------------------------------------- */
+.app-section {
+    padding: 0.9rem 0;
+    border-bottom: 1px solid var(--pico-muted-border-color);
+}
+.app-section:last-child { border-bottom: none; }
+.app-section h4 {
+    font-size: 0.68rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+    color: var(--pico-muted-color);
+    margin: 0 0 0.5rem;
+}
+
+/* -- Cover letter pre block ------------------------------------------------- */
+.cover-letter-pre {
+    white-space: pre-wrap;
+    font-size: 0.85em;
+    background: var(--pico-code-background, #030810);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    line-height: 1.65;
+    margin: 0 0 0.5rem;
+}
+
+/* -- Q&A items -------------------------------------------------------------- */
+.qa-item {
+    margin-bottom: 0.75rem;
+}
+.qa-item label {
+    display: block;
+    font-size: 0.82rem;
+    font-weight: 600;
+    margin-bottom: 0.3rem;
+}
+.qa-item textarea {
+    width: 100%;
+    resize: vertical;
+}
+.qa-save-btn {
+    font-size: 0.82rem !important;
+    padding: 0.4rem 1rem !important;
+    margin: 0 !important;
+}
+
+/* -- Resume section row ----------------------------------------------------- */
+.resume-section {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+.resume-download {
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+/* -- Re-tailor button ------------------------------------------------------- */
+.retailor-btn {
+    font-size: 0.8rem !important;
+    padding: 0.35rem 0.9rem !important;
+    margin: 0 !important;
+}
 """
 
 theme_headers = (Style(THEME_CSS),)

--- a/src/applybot/models/application.py
+++ b/src/applybot/models/application.py
@@ -77,6 +77,9 @@ def _app_to_doc(app: Application) -> dict[str, Any]:
 def _doc_to_app(doc: Any) -> Application:
     """Convert a Firestore document snapshot to an Application."""
     data = doc.to_dict()
+    # Migrate legacy "draft" status — removed from enum, treat as ready_for_review
+    if data.get("status") == "draft":
+        data["status"] = ApplicationStatus.READY_FOR_REVIEW.value
     return Application(id=doc.id, **data)
 
 

--- a/src/applybot/models/application.py
+++ b/src/applybot/models/application.py
@@ -16,7 +16,6 @@ STATUS_UPDATES_COLLECTION = "application_status_updates"
 
 
 class ApplicationStatus(str, enum.Enum):
-    DRAFT = "draft"
     READY_FOR_REVIEW = "ready_for_review"
     APPROVED = "approved"
     SUBMITTED = "submitted"
@@ -42,7 +41,7 @@ class Application(BaseModel):
     cover_letter: str = ""
     answers: dict[str, Any] = Field(default_factory=dict)
     profile_gaps: list[dict[str, str]] = Field(default_factory=list)
-    status: ApplicationStatus = ApplicationStatus.DRAFT
+    status: ApplicationStatus = ApplicationStatus.READY_FOR_REVIEW
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     submitted_at: datetime | None = None
 

--- a/src/applybot/tracking/tracker.py
+++ b/src/applybot/tracking/tracker.py
@@ -22,13 +22,8 @@ logger = logging.getLogger(__name__)
 
 # Valid state transitions
 VALID_TRANSITIONS: dict[ApplicationStatus, set[ApplicationStatus]] = {
-    ApplicationStatus.DRAFT: {
-        ApplicationStatus.READY_FOR_REVIEW,
-        ApplicationStatus.WITHDRAWN,
-    },
     ApplicationStatus.READY_FOR_REVIEW: {
         ApplicationStatus.APPROVED,
-        ApplicationStatus.DRAFT,  # back to draft for re-work
         ApplicationStatus.WITHDRAWN,
     },
     ApplicationStatus.APPROVED: {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -131,7 +131,7 @@ class TestApplicationModel:
             job_id=job.id,
             cover_letter="Dear hiring manager...",
             answers={"q1": "a1", "q2": "a2"},
-            status=ApplicationStatus.DRAFT,
+            status=ApplicationStatus.READY_FOR_REVIEW,
         )
         app = add_application(app)
 
@@ -148,12 +148,12 @@ class TestApplicationModel:
         )
         job = add_job(job)
 
-        app = Application(job_id=job.id, status=ApplicationStatus.DRAFT)
+        app = Application(job_id=job.id, status=ApplicationStatus.READY_FOR_REVIEW)
         app = add_application(app)
 
         fetched = get_application(app.id)
         assert fetched is not None
-        assert fetched.status == ApplicationStatus.DRAFT
+        assert fetched.status == ApplicationStatus.READY_FOR_REVIEW
 
     def test_status_update_tracking(self):
         job = Job(
@@ -164,14 +164,14 @@ class TestApplicationModel:
         )
         job = add_job(job)
 
-        app = Application(job_id=job.id, status=ApplicationStatus.DRAFT)
+        app = Application(job_id=job.id, status=ApplicationStatus.READY_FOR_REVIEW)
         app = add_application(app)
 
         update = ApplicationStatusUpdate(
             application_id=app.id,
-            status=ApplicationStatus.READY_FOR_REVIEW,
+            status=ApplicationStatus.APPROVED,
             source=UpdateSource.SYSTEM,
-            details="Auto-prepared",
+            details="Auto-approved",
         )
         add_status_update(update)
 

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -17,7 +17,9 @@ from applybot.tracking.tracker import (
 )
 
 
-def _create_application(status: ApplicationStatus = ApplicationStatus.DRAFT) -> str:
+def _create_application(
+    status: ApplicationStatus = ApplicationStatus.READY_FOR_REVIEW,
+) -> str:
     """Helper to create a test application and return its ID."""
     job = Job(
         title="Test Job",
@@ -33,14 +35,12 @@ def _create_application(status: ApplicationStatus = ApplicationStatus.DRAFT) -> 
 
 
 class TestStatusTransitions:
-    def test_valid_draft_to_ready(self):
-        app_id = _create_application(ApplicationStatus.DRAFT)
+    def test_valid_ready_to_withdrawn(self):
+        app_id = _create_application(ApplicationStatus.READY_FOR_REVIEW)
         from applybot.models.application import UpdateSource
 
-        app = update_status(
-            app_id, ApplicationStatus.READY_FOR_REVIEW, UpdateSource.SYSTEM
-        )
-        assert app.status == ApplicationStatus.READY_FOR_REVIEW
+        app = update_status(app_id, ApplicationStatus.WITHDRAWN, UpdateSource.MANUAL)
+        assert app.status == ApplicationStatus.WITHDRAWN
 
     def test_valid_ready_to_approved(self):
         app_id = _create_application(ApplicationStatus.READY_FOR_REVIEW)
@@ -67,8 +67,8 @@ class TestStatusTransitions:
         app = update_status(app_id, ApplicationStatus.INTERVIEW)
         assert app.status == ApplicationStatus.INTERVIEW
 
-    def test_invalid_draft_to_submitted(self):
-        app_id = _create_application(ApplicationStatus.DRAFT)
+    def test_invalid_ready_to_submitted(self):
+        app_id = _create_application(ApplicationStatus.READY_FOR_REVIEW)
         with pytest.raises(InvalidTransitionError):
             update_status(app_id, ApplicationStatus.SUBMITTED)
 
@@ -80,52 +80,50 @@ class TestStatusTransitions:
     def test_withdrawn_is_terminal(self):
         app_id = _create_application(ApplicationStatus.WITHDRAWN)
         with pytest.raises(InvalidTransitionError):
-            update_status(app_id, ApplicationStatus.DRAFT)
+            update_status(app_id, ApplicationStatus.READY_FOR_REVIEW)
 
     def test_nonexistent_application(self):
         with pytest.raises(ValueError, match="not found"):
             update_status("nonexistent_id", ApplicationStatus.APPROVED)
 
     def test_status_update_creates_record(self):
-        app_id = _create_application(ApplicationStatus.DRAFT)
+        app_id = _create_application(ApplicationStatus.READY_FOR_REVIEW)
         from applybot.models.application import UpdateSource
 
-        update_status(
-            app_id, ApplicationStatus.READY_FOR_REVIEW, UpdateSource.SYSTEM, "Test"
-        )
+        update_status(app_id, ApplicationStatus.APPROVED, UpdateSource.SYSTEM, "Test")
 
         updates = get_status_updates(app_id)
         assert len(updates) == 1
-        assert updates[0].status == ApplicationStatus.READY_FOR_REVIEW
+        assert updates[0].status == ApplicationStatus.APPROVED
         assert updates[0].details == "Test"
 
 
 class TestGetApplications:
     def test_filter_by_status(self):
-        _create_application(ApplicationStatus.DRAFT)
-        _create_application(ApplicationStatus.DRAFT)
         _create_application(ApplicationStatus.READY_FOR_REVIEW)
-
-        drafts = get_applications(status=ApplicationStatus.DRAFT)
-        assert len(drafts) == 2
+        _create_application(ApplicationStatus.READY_FOR_REVIEW)
+        _create_application(ApplicationStatus.APPROVED)
 
         ready = get_applications(status=ApplicationStatus.READY_FOR_REVIEW)
-        assert len(ready) == 1
+        assert len(ready) == 2
+
+        approved = get_applications(status=ApplicationStatus.APPROVED)
+        assert len(approved) == 1
 
     def test_get_all(self):
-        _create_application(ApplicationStatus.DRAFT)
         _create_application(ApplicationStatus.READY_FOR_REVIEW)
+        _create_application(ApplicationStatus.APPROVED)
         all_apps = get_applications()
         assert len(all_apps) == 2
 
 
 class TestGetSummary:
     def test_summary_counts(self):
-        _create_application(ApplicationStatus.DRAFT)
-        _create_application(ApplicationStatus.DRAFT)
         _create_application(ApplicationStatus.READY_FOR_REVIEW)
+        _create_application(ApplicationStatus.READY_FOR_REVIEW)
+        _create_application(ApplicationStatus.APPROVED)
 
         summary = get_summary()
-        assert summary["draft"] == 2
-        assert summary["ready_for_review"] == 1
+        assert summary["ready_for_review"] == 2
+        assert summary["approved"] == 1
         assert summary["total"] == 3


### PR DESCRIPTION
## Summary

Replaces the old collapsible card UI on the Applications page with a structured, multi-section layout featuring rich inline editing — all powered by HTMX partial swaps (no full-page reloads).

## Changes

### UI — `dashboard/pages/apps.py`
- Restructures each application card into distinct sections: **Details**, **Tailored Resume**, **Cover Letter**, and **Q&A Answers**
- **Cover letter**: read-only `<pre>` view with an Edit/Cancel/Save form (HTMX swap)
- **Q&A answers**: always-editable form with inline Save (HTMX swap)
- **Tailored resume**: filename download link + "Re-tailor Resume" button that triggers re-generation and swaps in the updated fragment
- New routes:
  - `GET /apps/{id}/cover-letter/edit` — cover letter edit fragment
  - `GET /apps/{id}/cover-letter/view` — cover letter read fragment
  - `POST /apps/{id}/cover-letter` — save cover letter
  - `POST /apps/{id}/answers` — save Q&A answers
  - `POST /apps/{id}/retailor` — re-tailor resume
  - `GET /apps/{id}/resume/download` — download tailored `.docx`
- "Back to Draft" action replaced with "Withdraw"

### Styling — `dashboard/theme.py`
- New CSS for `.app-section`, `.cover-letter-pre`, `.qa-item`, `.resume-section`, `.retailor-btn`

### Model / State machine
- Removes `DRAFT` status from `ApplicationStatus` — applications now default to `READY_FOR_REVIEW`
- Removes `DRAFT` from valid state transitions in `tracker.py`

### Tests
- Updates fixtures in `test_models.py` and `test_tracking.py` to reflect the removed `DRAFT` status