### PR TITLE
feat(profile): add ContactInfo model with email, LinkedIn, phone, and GitHub fields

### DIFF
--- a/src/applybot/application/question_answerer.py
+++ b/src/applybot/application/question_answerer.py
@@ -172,7 +172,7 @@ def _build_profile_context(profile: UserProfile) -> str:
             edu_text += f"- {edu.get('degree', '')} from {edu.get('school', '')}\n"
 
     return f"""Name: {profile.name}
-Email: {profile.email}
+Email: {profile.contact_info.email}
 Summary: {profile.summary}
 
 Skills: {skills}

--- a/src/applybot/dashboard/pages/profile.py
+++ b/src/applybot/dashboard/pages/profile.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -30,7 +31,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from applybot.dashboard.components import alert, page
-from applybot.models.profile import UserProfile, get_profile, save_profile
+from applybot.models.profile import ContactInfo, UserProfile, get_profile, save_profile
 from applybot.profile.enrichment import (
     enrich_profile_with_llm_async,
     extract_raw_resume_text,
@@ -52,6 +53,7 @@ _MIME_TYPES = {
 
 _FLASH_MESSAGES: dict[str, tuple[str, str]] = {
     "basic_saved": ("Basic profile info saved.", "success"),
+    "contact_saved": ("Contact information saved.", "success"),
     "resume_uploaded": ("Resume uploaded and parsed successfully.", "success"),
     "details_saved": ("Profile details saved.", "success"),
     "no_file": ("No file selected.", "error"),
@@ -64,7 +66,7 @@ _FLASH_MESSAGES: dict[str, tuple[str, str]] = {
 
 _PROFILE_FIELDS = [
     "name",
-    "email",
+    "contact_info",
     "summary",
     "skills",
     "experiences",
@@ -112,7 +114,10 @@ def _count_filled(profile: UserProfile) -> int:
     count = 0
     for fld in _PROFILE_FIELDS:
         val = getattr(profile, fld, None)
-        if isinstance(val, dict | list):
+        if isinstance(val, ContactInfo):
+            if any((val.email, val.linkedin, val.phone, val.github)):
+                count += 1
+        elif isinstance(val, dict | list):
             if val:
                 count += 1
         elif val:
@@ -128,6 +133,16 @@ def _map_resume_to_profile(parsed: ResumeData, profile: UserProfile) -> None:
         profile.name = resume_dict["name"]
     if not profile.summary and resume_dict.get("summary"):
         profile.summary = resume_dict["summary"]
+
+    # Best-effort: extract email from the raw contact_info string produced by the parser.
+    # The LLM enrichment step will do a more thorough extraction of all contact fields.
+    raw_contact = resume_dict.get("contact_info", "")
+    if raw_contact and not profile.contact_info.email:
+        email_match = re.search(
+            r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}", raw_contact
+        )
+        if email_match:
+            profile.contact_info.email = email_match.group(0)
 
     for section in parsed.sections:
         heading_lower = section.heading.lower()
@@ -272,11 +287,40 @@ def register(rt: Any) -> None:  # noqa: C901
             H3("Basic Information"),
             Form(
                 Label("Name", Input(name="name", value=p.name)),
-                Label("Email", Input(name="email", type="email", value=p.email)),
                 Label("Summary", Textarea(p.summary, name="summary", rows="4")),
                 Button("Save Basic Info", type="submit"),
                 method="post",
                 action="/profile",
+            ),
+            cls="profile-section",
+        )
+
+        # ── Contact Information ─────────────────────────────────────
+        ci = p.contact_info
+        contact_section = Div(
+            H3("Contact Information"),
+            Form(
+                Label("Email", Input(name="email", type="email", value=ci.email)),
+                Label(
+                    "LinkedIn",
+                    Input(
+                        name="linkedin",
+                        value=ci.linkedin,
+                        placeholder="https://linkedin.com/in/yourname",
+                    ),
+                ),
+                Label("Phone", Input(name="phone", type="tel", value=ci.phone)),
+                Label(
+                    "GitHub",
+                    Input(
+                        name="github",
+                        value=ci.github,
+                        placeholder="https://github.com/yourname",
+                    ),
+                ),
+                Button("Save Contact Info", type="submit"),
+                method="post",
+                action="/profile/contact",
             ),
             cls="profile-section",
         )
@@ -394,7 +438,7 @@ def register(rt: Any) -> None:  # noqa: C901
         profile_dict = {
             "id": p.id,
             "name": p.name,
-            "email": p.email,
+            "contact_info": p.contact_info.model_dump(),
             "summary": p.summary,
             "skills": p.skills,
             "experiences": p.experiences,
@@ -419,6 +463,7 @@ def register(rt: Any) -> None:  # noqa: C901
             flash,
             completeness,
             basic_section,
+            contact_section,
             resume_section,
             skills_section,
             exp_section,
@@ -429,17 +474,33 @@ def register(rt: Any) -> None:  # noqa: C901
         )
 
     @rt("/profile", methods=["post"])
-    def post_basic(
-        name: str = "", email: str = "", summary: str = ""
-    ) -> RedirectResponse:
+    def post_basic(name: str = "", summary: str = "") -> RedirectResponse:
         profile = get_profile()
         if profile is None:
-            profile = UserProfile(name=name, email=email)
+            profile = UserProfile(name=name)
         profile.name = name
-        profile.email = email
         profile.summary = summary
         save_profile(profile)
         return RedirectResponse("/profile?msg=basic_saved", status_code=303)
+
+    @rt("/profile/contact", methods=["post"])
+    def post_contact(
+        email: str = "",
+        linkedin: str = "",
+        phone: str = "",
+        github: str = "",
+    ) -> RedirectResponse:
+        profile = get_profile()
+        if profile is None:
+            profile = UserProfile(name="")
+        profile.contact_info = ContactInfo(
+            email=email.strip(),
+            linkedin=linkedin.strip(),
+            phone=phone.strip(),
+            github=github.strip(),
+        )
+        save_profile(profile)
+        return RedirectResponse("/profile?msg=contact_saved", status_code=303)
 
     @rt("/profile/resume", methods=["get"])
     def get_resume() -> Response:

--- a/src/applybot/discovery/tests/conftest.py
+++ b/src/applybot/discovery/tests/conftest.py
@@ -98,5 +98,5 @@ def mock_profile() -> UserProfile:
         "locations": ["Remote", "San Francisco"],
         "min_salary": 120000,
     }
-    profile.email = "test@example.com"
+    profile.contact_info.email = "test@example.com"
     return profile

--- a/src/applybot/models/README.md
+++ b/src/applybot/models/README.md
@@ -37,7 +37,8 @@ from applybot.models.application import ApplicationStatus, UpdateSource
 | Model | Key Fields | Firestore Collection |
 |---|---|---|
 | `Job` | id, title, company, location, description, url, source, posted_date, relevance_score, status | `jobs` |
-| `UserProfile` | name, email, summary, skills, experiences, education, preferences, resume_path | `profiles` (singleton doc `"default"`) |
+| `ContactInfo` | email, linkedin, phone, github | (nested in `UserProfile`) |
+| `UserProfile` | name, contact_info, summary, skills, experiences, education, preferences, resume_path | `profiles` (singleton doc `"default"`) |
 | `Application` | id, job_id, tailored_resume_path, cover_letter, answers, status, submitted_at | `applications` |
 | `ApplicationStatusUpdate` | id, application_id, status, source, details, timestamp | `application_status_updates` |
 

--- a/src/applybot/models/__init__.py
+++ b/src/applybot/models/__init__.py
@@ -26,6 +26,7 @@ from applybot.models.job import (
     update_job,
 )
 from applybot.models.profile import (
+    ContactInfo,
     UserProfile,
     delete_profile,
     get_profile,
@@ -37,6 +38,7 @@ __all__ = [
     "Application",
     "ApplicationStatus",
     "ApplicationStatusUpdate",
+    "ContactInfo",
     "Job",
     "JobSource",
     "JobStatus",

--- a/src/applybot/models/profile.py
+++ b/src/applybot/models/profile.py
@@ -15,12 +15,21 @@ COLLECTION = "profiles"
 PROFILE_DOC_ID = "default"
 
 
+class ContactInfo(BaseModel):
+    """Contact information for the user profile."""
+
+    email: str = ""
+    linkedin: str = ""
+    phone: str = ""
+    github: str = ""
+
+
 class UserProfile(BaseModel):
     """User profile stored in Firestore."""
 
     id: str = ""
     name: str
-    email: str = ""
+    contact_info: ContactInfo = Field(default_factory=ContactInfo)
     summary: str = ""
     skills: dict[str, Any] = Field(default_factory=dict)
     experiences: list[Any] = Field(default_factory=list)
@@ -42,6 +51,11 @@ def _profile_to_doc(profile: UserProfile) -> dict[str, Any]:
 def _doc_to_profile(doc: Any) -> UserProfile:
     """Convert a Firestore document snapshot to a UserProfile."""
     data = doc.to_dict()
+    # Migrate legacy flat 'email' field into the nested contact_info object.
+    if "email" in data and "contact_info" not in data:
+        data["contact_info"] = {"email": data.pop("email")}
+    elif "email" in data:
+        data.pop("email")
     return UserProfile(id=doc.id, **data)
 
 
@@ -65,11 +79,15 @@ def save_profile(profile: UserProfile) -> UserProfile:
 def update_profile_fields(**fields: Any) -> UserProfile:
     """Update specific fields on the profile. Raises ValueError if no profile exists."""
     fields["updated_at"] = datetime.now(UTC)
+    # Serialize any nested Pydantic models to dicts for Firestore compatibility.
+    serialized = {
+        k: v.model_dump() if isinstance(v, BaseModel) else v for k, v in fields.items()
+    }
     ref = get_db().collection(COLLECTION).document(PROFILE_DOC_ID)
     doc = ref.get()
     if not doc.exists:
         raise ValueError("No profile exists. Create one first.")
-    ref.update(fields)
+    ref.update(serialized)
     # Re-read and return
     updated_doc = ref.get()
     return _doc_to_profile(updated_doc)

--- a/src/applybot/profile/README.md
+++ b/src/applybot/profile/README.md
@@ -64,11 +64,11 @@ Parsing is purely heuristic — no LLM is involved. Each format uses text extrac
 5. Lines that *contain* a known multi-word phrase such as `"programming languages"`
    (handles headings like "Familiar Programming Languages and Software").
 
-Sections are mapped to profile fields via `_map_resume_to_profile()` in `dashboard/pages/profile.py` by keyword matching: headings containing "skill/technologies/tools" → `skills`, "experience/employment/work history/career" → `experiences`, "education/academic/degree/university/school" → `education`.
+Sections are mapped to profile fields via `_map_resume_to_profile()` in `dashboard/pages/profile.py` by keyword matching: headings containing "skill/technologies/tools" → `skills`, "experience/employment/work history/career" → `experiences`, "education/academic/degree/university/school" → `education`. The raw contact line is also scanned with a regex to extract an email address into `contact_info.email`.
 
 #### LLM enrichment (post-parse)
 
-After the heuristic pass saves the profile, the upload handler fires an async background task that calls the LLM to review the existing profile + parsed resume and write back a more complete profile. See `enrichment.py`.
+After the heuristic pass saves the profile, the upload handler fires an async background task that calls the LLM to review the existing profile + parsed resume and write back a more complete profile. The LLM also extracts and populates all four `contact_info` fields (email, linkedin, phone, github) from the resume text. See `enrichment.py`.
 
 ```python
 from applybot.profile.enrichment import enrich_profile_with_llm, enrich_profile_with_llm_async

--- a/src/applybot/profile/enrichment.py
+++ b/src/applybot/profile/enrichment.py
@@ -30,6 +30,12 @@ Rules:
 - If the profile already looks complete and the resume adds nothing new, return the profile unchanged.
 - Expand skills, experiences, and education from the resume if they are missing or incomplete in the profile.
 - Write a strong professional summary if the existing one is empty or weak.
+- Extract contact information from the resume and populate the contact_info fields:
+  - contact_info.email: email address
+  - contact_info.linkedin: LinkedIn profile URL or username
+  - contact_info.phone: phone number
+  - contact_info.github: GitHub profile URL or username
+  Only update a contact_info field if the resume clearly contains that information and the field is currently empty.
 """
 
 
@@ -88,6 +94,15 @@ def enrich_profile_with_llm(profile: UserProfile, resume_text: str) -> UserProfi
     updated.enrichment_warning = ""
     if not updated.name:
         updated.name = profile.name
+    # Preserve any contact fields the LLM left blank but the profile already had
+    if not updated.contact_info.email and profile.contact_info.email:
+        updated.contact_info.email = profile.contact_info.email
+    if not updated.contact_info.linkedin and profile.contact_info.linkedin:
+        updated.contact_info.linkedin = profile.contact_info.linkedin
+    if not updated.contact_info.phone and profile.contact_info.phone:
+        updated.contact_info.phone = profile.contact_info.phone
+    if not updated.contact_info.github and profile.contact_info.github:
+        updated.contact_info.github = profile.contact_info.github
 
     save_profile(updated)
     logger.info("LLM profile enrichment complete for profile %r", profile.id)

--- a/src/applybot/profile/enrichment.py
+++ b/src/applybot/profile/enrichment.py
@@ -86,6 +86,7 @@ def enrich_profile_with_llm(profile: UserProfile, resume_text: str) -> UserProfi
         UserProfile,
         system=_SYSTEM_PROMPT,
         tier="smart",
+        max_tokens=8192,
     )
 
     # Always preserve identity/path fields and guard against a missing name

--- a/src/applybot/profile/manager.py
+++ b/src/applybot/profile/manager.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from applybot.models.profile import (
+    ContactInfo,
     UserProfile,
     save_profile,
     update_profile_fields,
@@ -33,7 +34,7 @@ class ProfileManager:
         profile = _get_profile()
         if profile is not None:
             return profile
-        profile = UserProfile(name=name, email=email)
+        profile = UserProfile(name=name, contact_info=ContactInfo(email=email))
         return save_profile(profile)
 
     def update_profile(self, **kwargs: Any) -> UserProfile:
@@ -68,7 +69,7 @@ class ProfileManager:
         path.parent.mkdir(parents=True, exist_ok=True)
         data = {
             "name": profile.name,
-            "email": profile.email,
+            "contact_info": profile.contact_info.model_dump(),
             "summary": profile.summary,
             "skills": profile.skills,
             "experiences": profile.experiences,
@@ -84,6 +85,9 @@ class ProfileManager:
         """Import profile from a JSON file, creating or updating the DB record."""
         path = path or DATA_DIR / "profile.json"
         data = json.loads(path.read_text(encoding="utf-8"))
+        # Deserialize nested contact_info dict into a ContactInfo object.
+        if "contact_info" in data and isinstance(data["contact_info"], dict):
+            data["contact_info"] = ContactInfo(**data["contact_info"])
         profile = _get_profile()
         if profile is None:
             profile = UserProfile(**data)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,7 +18,7 @@ from applybot.models.job import (
     get_all_job_urls,
     get_job,
 )
-from applybot.models.profile import UserProfile, get_profile, save_profile
+from applybot.models.profile import ContactInfo, UserProfile, get_profile, save_profile
 
 
 class TestJobModel:
@@ -81,7 +81,7 @@ class TestUserProfileModel:
     def test_create_profile(self):
         profile = UserProfile(
             name="Test User",
-            email="test@example.com",
+            contact_info=ContactInfo(email="test@example.com"),
             summary="ML engineer with 5 years experience",
             skills={"technical": ["Python", "PyTorch", "ROS"]},
             experiences=[
@@ -96,6 +96,7 @@ class TestUserProfileModel:
 
         assert profile.id != ""
         assert profile.name == "Test User"
+        assert profile.contact_info.email == "test@example.com"
         assert "Python" in profile.skills["technical"]
 
     def test_profile_json_fields(self):


### PR DESCRIPTION
## Summary

Replaces the flat `email` field on `UserProfile` with a structured `ContactInfo` nested model containing four dedicated fields: `email`, `linkedin`, `phone`, and `github`.

## Changes

### Model (`models/profile.py`)
- Added `ContactInfo` Pydantic model with `email`, `linkedin`, `phone`, `github` fields
- Replaced `UserProfile.email: str` with `UserProfile.contact_info: ContactInfo`
- Added Firestore migration in `_doc_to_profile`: existing docs with a flat `email` key are automatically promoted to `contact_info.email` on read (no data migration script needed)
- Fixed `update_profile_fields` to serialize `BaseModel` values to dicts before calling `ref.update()` — previously would have raised a Firestore type error if passed a `ContactInfo` object

### Package exports (`models/__init__.py`)
- Added `ContactInfo` to the package import and `__all__`

### Dashboard (`dashboard/pages/profile.py`)
- Removed `email` from the Basic Info form
- Added a new **Contact Information** section with individual inputs for email, LinkedIn, phone, and GitHub, saved via `POST /profile/contact`
- Added `contact_saved` flash message
- Updated `_count_filled` to handle the `ContactInfo` type
- Updated raw JSON display to emit `contact_info` dict

### Resume parsing (`dashboard/pages/profile.py`)
- `_map_resume_to_profile` now extracts an email address from the raw parsed contact line via regex into `contact_info.email` (best-effort; LLM enrichment handles the rest)

### LLM enrichment (`profile/enrichment.py`)
- Updated system prompt to instruct the LLM to extract all four contact fields from the resume text
- Added fallback preservation: any contact fields the LLM leaves blank but the profile already had are restored

### Profile manager (`profile/manager.py`)
- `ContactInfo` moved to module-level import
- `get_or_create_profile` wraps the `email` argument in a `ContactInfo` object
- `export_profile_json` emits `contact_info` dict instead of flat `email`
- `import_profile_json` deserializes the `contact_info` dict back into a `ContactInfo` object before constructing `UserProfile`

### Other call sites
- `application/question_answerer.py`: `profile.email` → `profile.contact_info.email`
- `discovery/tests/conftest.py`: same fix in the mock profile fixture

### Tests & docs
- `tests/test_models.py`: updated to use `ContactInfo(email=...)` and assert on `profile.contact_info.email`
- `models/README.md`: added `ContactInfo` row to the models table
- `profile/README.md`: documented email extraction in heuristic parsing and LLM enrichment sections

## Migration

Existing Firestore profiles with a flat `email` field will be automatically migrated on the next read — no manual data migration needed.