### PR TITLE
refactor: fold model CRUD into FirestoreModel base, drop audit trail

### DIFF
--- a/infra/firestore.tf
+++ b/infra/firestore.tf
@@ -48,21 +48,3 @@ resource "google_firestore_index" "apps_status_created" {
   depends_on = [google_firestore_database.main]
 }
 
-# Composite index: application_status_updates — application_id + timestamp
-resource "google_firestore_index" "status_updates_app_time" {
-  project    = var.project_id
-  database   = google_firestore_database.main.name
-  collection = "application_status_updates"
-
-  fields {
-    field_path = "application_id"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "timestamp"
-    order      = "ASCENDING"
-  }
-
-  depends_on = [google_firestore_database.main]
-}

--- a/src/applybot/application/preparer.py
+++ b/src/applybot/application/preparer.py
@@ -10,8 +10,8 @@ from applybot.application.question_answerer import (
     generate_cover_letter,
 )
 from applybot.application.resume_tailor import tailor_resume
-from applybot.models.application import Application, ApplicationStatus, add_application
-from applybot.models.job import Job, JobStatus, query_jobs, update_job
+from applybot.models.application import Application, ApplicationStatus
+from applybot.models.job import Job, JobStatus
 from applybot.profile.manager import ProfileManager
 
 logger = logging.getLogger(__name__)
@@ -70,7 +70,7 @@ def prepare_application(
         profile_gaps=[{"question": g.question, "context": g.context} for g in all_gaps],
         status=ApplicationStatus.READY_FOR_REVIEW,
     )
-    application = add_application(application)
+    application.save()
 
     logger.info(
         "Application prepared: id=%s for job %s (%s at %s), %d gaps",
@@ -87,7 +87,7 @@ def prepare_all_approved() -> list[tuple[Application, list[ProfileGap]]]:
     """Prepare applications for all jobs with APPROVED status."""
     results: list[tuple[Application, list[ProfileGap]]] = []
 
-    approved_jobs = query_jobs(status=JobStatus.APPROVED, limit=500)
+    approved_jobs = Job.query(status=JobStatus.APPROVED, limit=500)
 
     logger.info("Found %d approved jobs to prepare", len(approved_jobs))
 
@@ -95,7 +95,7 @@ def prepare_all_approved() -> list[tuple[Application, list[ProfileGap]]]:
         try:
             app, gaps = prepare_application(job)
             results.append((app, gaps))
-            update_job(job.id, status=JobStatus.REVIEWING)
+            Job.update(job.id, status=JobStatus.REVIEWING)
         except Exception:
             logger.exception("Failed to prepare application for job %s", job.id)
 

--- a/src/applybot/dashboard/components.py
+++ b/src/applybot/dashboard/components.py
@@ -50,9 +50,9 @@ def nav() -> Nav:
     """Top navigation bar with approved-jobs count badge on the Jobs link."""
     approved_count = 0
     try:
-        from applybot.models.job import count_jobs_by_status
+        from applybot.models.job import Job
 
-        approved_count = count_jobs_by_status().get("approved", 0)
+        approved_count = Job.count_by_status().get("approved", 0)
     except Exception:
         logger.warning(
             "Failed to fetch approved job count for nav badge", exc_info=True

--- a/src/applybot/dashboard/pages/apps.py
+++ b/src/applybot/dashboard/pages/apps.py
@@ -33,15 +33,8 @@ from applybot.dashboard.components import (
     page,
     status_badge,
 )
-from applybot.models.application import (
-    Application,
-    ApplicationStatus,
-    UpdateSource,
-    get_application,
-    query_applications,
-    update_application,
-)
-from applybot.models.job import Job, get_job
+from applybot.models.application import Application, ApplicationStatus
+from applybot.models.job import Job
 from applybot.profile.manager import ProfileManager
 from applybot.storage import download_file
 from applybot.tracking.tracker import InvalidTransitionError, update_status
@@ -324,7 +317,7 @@ def register(rt: Any) -> None:
                 app_status = ApplicationStatus(status)
             except ValueError:
                 pass
-        apps = query_applications(status=app_status, limit=200)
+        apps = Application.query(status=app_status, limit=200)
 
         form = filter_form(
             "/apps",
@@ -339,7 +332,7 @@ def register(rt: Any) -> None:
             ],
         )
         count_text = P(Strong(f"{len(apps)} applications"))
-        cards = [_build_app_card(app, get_job(app.job_id)) for app in apps] or [
+        cards = [_build_app_card(app, Job.get(app.job_id)) for app in apps] or [
             alert("No applications found.")
         ]
         return page(H1("Applications"), form, count_text, *cards, title="Applications")
@@ -349,7 +342,7 @@ def register(rt: Any) -> None:
     @rt("/apps/{app_id}/approve", methods=["post"])
     def post_approve(app_id: str) -> object:
         try:
-            update_status(app_id, ApplicationStatus.APPROVED, UpdateSource.MANUAL)
+            update_status(app_id, ApplicationStatus.APPROVED)
             return confirmed_card("app", app_id, f"Application #{app_id}", "Approved")
         except (ValueError, InvalidTransitionError) as e:
             return alert(str(e), "error")
@@ -357,7 +350,7 @@ def register(rt: Any) -> None:
     @rt("/apps/{app_id}/withdraw", methods=["post"])
     def post_withdraw(app_id: str) -> object:
         try:
-            update_status(app_id, ApplicationStatus.WITHDRAWN, UpdateSource.MANUAL)
+            update_status(app_id, ApplicationStatus.WITHDRAWN)
             return confirmed_card("app", app_id, f"Application #{app_id}", "Withdrawn")
         except (ValueError, InvalidTransitionError) as e:
             return alert(str(e), "error")
@@ -366,12 +359,12 @@ def register(rt: Any) -> None:
 
     @rt("/apps/{app_id}/cover-letter", methods=["post"])
     def post_cover_letter(app_id: str, cover_letter: str = "") -> object:
-        app = get_application(app_id)
+        app = Application.get(app_id)
         if app is None:
             return alert(f"Application {app_id} not found.", "error")
         is_terminal = app.status in _TERMINAL
         if not is_terminal:
-            update_application(app_id, cover_letter=cover_letter)
+            Application.update(app_id, cover_letter=cover_letter)
         return _cover_letter_section(
             app_id, cover_letter, terminal=is_terminal, saved=not is_terminal
         )
@@ -380,7 +373,7 @@ def register(rt: Any) -> None:
 
     @rt("/apps/{app_id}/answers", methods=["post"])
     async def post_answers(app_id: str, request: Request) -> object:
-        app = get_application(app_id)
+        app = Application.get(app_id)
         if app is None:
             return alert(f"Application {app_id} not found.", "error")
         form = await request.form()
@@ -394,7 +387,7 @@ def register(rt: Any) -> None:
             i += 1
         is_terminal = app.status in _TERMINAL
         if not is_terminal:
-            update_application(app_id, answers=answers)
+            Application.update(app_id, answers=answers)
             app.answers = answers
         return _qa_section(app, terminal=is_terminal, saved=not is_terminal)
 
@@ -402,12 +395,12 @@ def register(rt: Any) -> None:
 
     @rt("/apps/{app_id}/retailor", methods=["post"])
     def post_retailor(app_id: str) -> object:
-        app = get_application(app_id)
+        app = Application.get(app_id)
         if app is None:
             return alert(f"Application {app_id} not found.", "error")
         if app.status in _TERMINAL:
             return alert("Cannot re-tailor a terminal application.", "error")
-        job = get_job(app.job_id)
+        job = Job.get(app.job_id)
         if job is None:
             return alert(f"Job {app.job_id} not found for this application.", "error")
         try:
@@ -415,7 +408,7 @@ def register(rt: Any) -> None:
             if profile is None:
                 return alert("No profile found -- cannot re-tailor resume.", "error")
             new_path = tailor_resume(job, profile)
-            update_application(app_id, tailored_resume_path=str(new_path))
+            Application.update(app_id, tailored_resume_path=str(new_path))
             app.tailored_resume_path = str(new_path)
             return _resume_section(app)
         except Exception as exc:
@@ -425,7 +418,7 @@ def register(rt: Any) -> None:
 
     @rt("/apps/{app_id}/resume/download", methods=["get"])
     def get_resume_download(app_id: str) -> object:
-        app = get_application(app_id)
+        app = Application.get(app_id)
         if app is None or not app.tailored_resume_path:
             return alert("Resume not found.", "error")
         try:

--- a/src/applybot/dashboard/pages/jobs.py
+++ b/src/applybot/dashboard/pages/jobs.py
@@ -28,7 +28,7 @@ from applybot.dashboard.components import (
     page,
     status_badge,
 )
-from applybot.models.job import Job, JobStatus, get_job, query_jobs, update_job
+from applybot.models.job import Job, JobStatus
 
 logger = logging.getLogger(__name__)
 
@@ -240,7 +240,7 @@ def _build_jobs_list(
         except ValueError:
             pass
 
-    jobs = query_jobs(
+    jobs = Job.query(
         status=job_status,
         min_score=min_score if min_score > 0 else None,
         limit=200,
@@ -266,7 +266,7 @@ def register(rt: Any) -> None:
     @rt("/jobs", methods=["get"])
     def get(status: str = "new", min_score: int = 0) -> tuple[object, ...]:
         # Always load approved jobs for the staging area (independent of browse filter)
-        approved_jobs = query_jobs(status=JobStatus.APPROVED, limit=100)
+        approved_jobs = Job.query(status=JobStatus.APPROVED, limit=100)
 
         staging = _build_staging_area(approved_jobs)
 
@@ -328,16 +328,16 @@ def register(rt: Any) -> None:
             result_alert = alert(f"Unexpected error: {str(e)[:150]}", "error")
 
         # OOB-refresh staging area (approved jobs are now in REVIEWING)
-        new_approved = query_jobs(status=JobStatus.APPROVED, limit=100)
+        new_approved = Job.query(status=JobStatus.APPROVED, limit=100)
         oob = _build_staging_area(new_approved, oob=True)
         return NotStr(to_xml(result_alert) + to_xml(oob))
 
     @rt("/jobs/unstage-all")
     def post_unstage_all(status: str = "new", min_score: int = 0) -> object:
         """Return all approved jobs back to NEW, clearing the staging area."""
-        approved = query_jobs(status=JobStatus.APPROVED, limit=100)
+        approved = Job.query(status=JobStatus.APPROVED, limit=100)
         for job in approved:
-            update_job(job.id, status=JobStatus.NEW)
+            Job.update(job.id, status=JobStatus.NEW)
         staging = _build_staging_area([])
         browse_oob = _build_jobs_list(status, min_score, oob=True)
         return NotStr(to_xml(staging) + to_xml(browse_oob))
@@ -345,25 +345,25 @@ def register(rt: Any) -> None:
     @rt("/jobs/{job_id}/unapprove")
     def post_unapprove(job_id: str, status: str = "new", min_score: int = 0) -> object:
         """Return an approved job back to NEW, removing it from the staging area."""
-        job = get_job(job_id)
+        job = Job.get(job_id)
         if job is None:
             return alert("Job not found.", "error")
         if job.status != JobStatus.APPROVED:
             return alert(f"Job is {job.status.value}, not approved.", "error")
-        update_job(job_id, status=JobStatus.NEW)
-        new_approved = query_jobs(status=JobStatus.APPROVED, limit=100)
+        Job.update(job_id, status=JobStatus.NEW)
+        new_approved = Job.query(status=JobStatus.APPROVED, limit=100)
         staging = _build_staging_area(new_approved)
         browse_oob = _build_jobs_list(status, min_score, oob=True)
         return NotStr(to_xml(staging) + to_xml(browse_oob))
 
     @rt("/jobs/{job_id}/approve")
     def post(job_id: str, status: str = "new", min_score: int = 0) -> object:
-        job = get_job(job_id)
+        job = Job.get(job_id)
         if job is None:
             return alert("Job not found.", "error")
         if job.status != JobStatus.NEW:
             return alert(f"Job is {job.status.value}, not new.", "error")
-        update_job(job_id, status=JobStatus.APPROVED)
+        Job.update(job_id, status=JobStatus.APPROVED)
         card = confirmed_card(
             "job",
             job.id,
@@ -371,17 +371,17 @@ def register(rt: Any) -> None:
             "Approved — added to staging",
         )
         # OOB-refresh staging area and browse list
-        new_approved = query_jobs(status=JobStatus.APPROVED, limit=100)
+        new_approved = Job.query(status=JobStatus.APPROVED, limit=100)
         staging_oob = _build_staging_area(new_approved, oob=True)
         browse_oob = _build_jobs_list(status, min_score, oob=True)
         return NotStr(to_xml(card) + to_xml(staging_oob) + to_xml(browse_oob))
 
     @rt("/jobs/{job_id}/skip")
     def post_skip(job_id: str, status: str = "new", min_score: int = 0) -> object:
-        job = get_job(job_id)
+        job = Job.get(job_id)
         if job is None:
             return alert("Job not found.", "error")
-        update_job(job_id, status=JobStatus.SKIPPED)
+        Job.update(job_id, status=JobStatus.SKIPPED)
         card = confirmed_card("job", job.id, f"{job.title} at {job.company}", "Skipped")
         browse_oob = _build_jobs_list(status, min_score, oob=True)
         return NotStr(to_xml(card) + to_xml(browse_oob))

--- a/src/applybot/dashboard/pages/overview.py
+++ b/src/applybot/dashboard/pages/overview.py
@@ -9,8 +9,8 @@ from fasthtml.common import H1, Article, Button, Div, Grid, NotStr, Span, to_xml
 
 from applybot.dashboard.components import alert, page, progress_table, stat_card
 from applybot.discovery.orchestrator import run_discovery
-from applybot.models.application import count_applications_by_status
-from applybot.models.job import count_jobs_by_status
+from applybot.models.application import Application
+from applybot.models.job import Job
 
 logger = logging.getLogger(__name__)
 
@@ -24,9 +24,9 @@ def _build_stats_grid(
     app_counts: dict[str, int] | None = None,
 ) -> Grid:
     if job_counts is None:
-        job_counts = count_jobs_by_status()
+        job_counts = Job.count_by_status()
     if app_counts is None:
-        app_counts = count_applications_by_status()
+        app_counts = Application.count_by_status()
     extra: dict[str, Any] = {"id": "overview-stats"}
     if oob:
         extra["hx_swap_oob"] = "outerHTML"
@@ -42,8 +42,8 @@ def _build_stats_grid(
 def register(rt: Any) -> None:
     @rt("/", methods=["get"])
     def get() -> tuple[object, ...]:
-        job_counts = count_jobs_by_status()
-        app_counts = count_applications_by_status()
+        job_counts = Job.count_by_status()
+        app_counts = Application.count_by_status()
         total_apps = app_counts.get("total", 0)
 
         stats = _build_stats_grid(job_counts=job_counts, app_counts=app_counts)

--- a/src/applybot/dashboard/pages/profile.py
+++ b/src/applybot/dashboard/pages/profile.py
@@ -31,7 +31,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from applybot.dashboard.components import alert, page
-from applybot.models.profile import ContactInfo, UserProfile, get_profile, save_profile
+from applybot.models.profile import ContactInfo, UserProfile
 from applybot.profile.enrichment import (
     enrich_profile_with_llm_async,
     extract_raw_resume_text,
@@ -248,7 +248,7 @@ def _prefs_display(prefs: dict[str, Any]) -> Any:
 def register(rt: Any) -> None:  # noqa: C901
     @rt("/profile", methods=["get"])
     def get(msg: str = "", error: str = "") -> Any:
-        profile = get_profile()
+        profile = UserProfile.get()
         p = profile or UserProfile(name="")
 
         # Flash message
@@ -475,12 +475,12 @@ def register(rt: Any) -> None:  # noqa: C901
 
     @rt("/profile", methods=["post"])
     def post_basic(name: str = "", summary: str = "") -> RedirectResponse:
-        profile = get_profile()
+        profile = UserProfile.get()
         if profile is None:
             profile = UserProfile(name=name)
         profile.name = name
         profile.summary = summary
-        save_profile(profile)
+        profile.save()
         return RedirectResponse("/profile?msg=basic_saved", status_code=303)
 
     @rt("/profile/contact", methods=["post"])
@@ -490,7 +490,7 @@ def register(rt: Any) -> None:  # noqa: C901
         phone: str = "",
         github: str = "",
     ) -> RedirectResponse:
-        profile = get_profile()
+        profile = UserProfile.get()
         if profile is None:
             profile = UserProfile(name="")
         profile.contact_info = ContactInfo(
@@ -499,12 +499,12 @@ def register(rt: Any) -> None:  # noqa: C901
             phone=phone.strip(),
             github=github.strip(),
         )
-        save_profile(profile)
+        profile.save()
         return RedirectResponse("/profile?msg=contact_saved", status_code=303)
 
     @rt("/profile/resume", methods=["get"])
     def get_resume() -> Response:
-        profile = get_profile()
+        profile = UserProfile.get()
         object_name = profile.resume_path if profile and profile.resume_path else None
         if object_name and file_exists(object_name):
             return get_download_response(object_name, Path(object_name).name)
@@ -548,7 +548,7 @@ def register(rt: Any) -> None:  # noqa: C901
                 logger.exception("Failed to parse uploaded resume")
                 return RedirectResponse("/profile?error=parse_failed", status_code=303)
 
-            profile = get_profile()
+            profile = UserProfile.get()
             if profile is None:
                 profile = UserProfile(name="")
 
@@ -557,7 +557,7 @@ def register(rt: Any) -> None:  # noqa: C901
 
             _map_resume_to_profile(parsed, profile)
 
-            save_profile(profile)
+            profile.save()
 
             # Kick off LLM enrichment in the background — won't delay the response.
             # Raw file text is used (not the heuristic-parsed JSON) so the LLM sees
@@ -576,7 +576,7 @@ def register(rt: Any) -> None:  # noqa: C901
         education: str = "",
         preferences: str = "",
     ) -> RedirectResponse:
-        profile = get_profile()
+        profile = UserProfile.get()
         if profile is None:
             profile = UserProfile(name="")
 
@@ -605,5 +605,5 @@ def register(rt: Any) -> None:  # noqa: C901
             logger.exception("Invalid JSON submitted to /profile/details")
             return RedirectResponse("/profile?error=invalid_json", status_code=303)
 
-        save_profile(profile)
+        profile.save()
         return RedirectResponse("/profile?msg=details_saved", status_code=303)

--- a/src/applybot/discovery/orchestrator.py
+++ b/src/applybot/discovery/orchestrator.py
@@ -18,7 +18,7 @@ from applybot.discovery.scrapers.euremotejobs import EuRemoteJobsScraper
 from applybot.discovery.scrapers.greenhouse import GreenhouseScraper
 from applybot.discovery.scrapers.lever import LeverScraper
 from applybot.discovery.scrapers.serpapi import SerpAPIScraper
-from applybot.models.job import Job, JobSource, JobStatus, add_jobs, get_all_job_urls
+from applybot.models.job import Job, JobSource, JobStatus
 from applybot.profile.manager import ProfileManager
 
 logger = logging.getLogger(__name__)
@@ -169,7 +169,7 @@ async def run_discovery(
 
 def _save_jobs(ranked: list[tuple[RawJob, int, str]]) -> int:
     """Save ranked jobs to the database, skipping existing URLs."""
-    existing_urls = get_all_job_urls()
+    existing_urls = Job.all_urls()
     new_jobs: list[Job] = []
 
     for raw_job, score, reasoning in ranked:
@@ -195,7 +195,7 @@ def _save_jobs(ranked: list[tuple[RawJob, int, str]]) -> int:
         existing_urls.add(raw_job.url)
 
     if new_jobs:
-        add_jobs(new_jobs)
+        Job.add_many(new_jobs)
     return len(new_jobs)
 
 

--- a/src/applybot/models/README.md
+++ b/src/applybot/models/README.md
@@ -8,8 +8,8 @@ Pydantic data models and Firestore CRUD functions. This is the foundational data
 ## File Structure
 ```
 models/
-├── application.py      # `Application`, `ApplicationStatusUpdate` models and CRUD functions
-├── base.py             # Firestore client singleton (`get_db()`, `init_db()`)
+├── application.py      # `Application` model (inherits `FirestoreModel`) + `ApplicationStatus` enum
+├── base.py             # Firestore client (`lru_cache` singleton: `get_db`, `init_db`) + `FirestoreModel` base class
 ├── job.py              # `Job` model and CRUD functions for job listings
 ├── profile.py          # `UserProfile` model with singleton document pattern
 ├── requirements.in     # runtime deps for this module (mirrors root pyproject.toml)
@@ -99,14 +99,26 @@ commit would be slow and brittle. Run the model tests manually (as above) or
 via CI before merging.
 ## Public API
 
+`Job` and `Application` inherit from `FirestoreModel` (in `base.py`), which
+provides document-level CRUD (`get`/`save`/`update`/`count_by_status`) against
+a single auto-ID Firestore collection. `UserProfile` is a standalone
+`pydantic.BaseModel` — its singleton-document pattern (fixed id `"default"`,
+replace-on-save) does not fit the auto-ID collection shape, so it keeps its own
+classmethods.
+
 ### Database Setup
 
 ```python
 from applybot.models.base import get_db, init_db
 
-init_db()              # Verify Firestore connection (no schema needed)
-db = get_db()          # Get Firestore Client singleton
+init_db()              # Eagerly construct the Firestore client (no network round-trip)
+db = get_db()          # Cached client singleton (functools.lru_cache, maxsize=1)
+# To force re-init (e.g. in tests): get_db.cache_clear()
 ```
+
+`get_db()` reads `FIRESTORE_EMULATOR_HOST`/`GOOGLE_CLOUD_PROJECT` from the
+environment (test suite) and falls back to Application Default Credentials
+otherwise. The client is cached for the process lifetime.
 
 ### Enums
 
@@ -115,9 +127,9 @@ from applybot.models.job import JobStatus, JobSource
 # JobStatus: NEW, REVIEWING, APPROVED, SKIPPED, APPLIED, REJECTED
 # JobSource: SERPAPI, GREENHOUSE, LEVER, EU_REMOTE_JOBS, MANUAL
 
-from applybot.models.application import ApplicationStatus, UpdateSource
-# ApplicationStatus: DRAFT → READY_FOR_REVIEW → APPROVED → SUBMITTED → RECEIVED → INTERVIEW → OFFER / REJECTED / WITHDRAWN
-# UpdateSource: MANUAL, GMAIL, SYSTEM
+from applybot.models.application import ApplicationStatus
+# ApplicationStatus: READY_FOR_REVIEW, APPROVED, SUBMITTED, RECEIVED,
+#                    INTERVIEW, OFFER, REJECTED, WITHDRAWN
 ```
 
 ### Pydantic Models
@@ -126,38 +138,40 @@ from applybot.models.application import ApplicationStatus, UpdateSource
 
 | Model | Key Fields | Firestore Collection |
 |---|---|---|
-| `Job` | id, title, company, location, description, url, source, posted_date, relevance_score, status | `jobs` |
+| `FirestoreModel` | id | (base class — `COLLECTION` set by subclasses) |
+| `Job` | id, title, company, location, description, url, source, posted_date, discovered_date, relevance_score, status, hard_requirements, application_questions | `jobs` |
 | `ContactInfo` | email, linkedin, phone, github | (nested in `UserProfile`) |
-| `UserProfile` | name, contact_info, summary, skills, experiences, education, preferences, resume_path | `profiles` (singleton doc `"default"`) |
-| `Application` | id, job_id, tailored_resume_path, cover_letter, answers, status, submitted_at | `applications` |
-| `ApplicationStatusUpdate` | id, application_id, status, source, details, timestamp | `application_status_updates` |
+| `UserProfile` | id, name, contact_info, summary, skills, experiences, education, preferences, resume_path, updated_at | `profiles` (singleton doc `"default"`) |
+| `Application` | id, job_id, tailored_resume_path, cover_letter, answers, profile_gaps, status, created_at, submitted_at | `applications` |
 
-### CRUD Functions
+### CRUD API
 
-**Jobs** (`job.py`):
-- `get_job(job_id: str) -> Job | None`
-- `add_job(job: Job) -> str` — returns generated doc ID
-- `add_jobs(jobs: list[Job]) -> int` — batch write, returns count
-- `update_job(job_id: str, **fields) -> None`
-- `query_jobs(status, min_score, limit) -> list[Job]`
-- `get_all_job_urls() -> set[str]`
-- `count_jobs_by_status() -> dict[str, int]`
+All access is via classmethods on the models (no module-level CRUD functions).
 
-**Applications** (`application.py`):
-- `get_application(app_id: str) -> Application | None`
-- `add_application(app: Application) -> str`
-- `update_application(app_id: str, **fields) -> None`
-- `query_applications(status, limit) -> list[Application]`
-- `count_applications_by_status() -> dict[str, int]`
-- `add_status_update(update: ApplicationStatusUpdate) -> str`
-- `get_status_updates(app_id: str) -> list[ApplicationStatusUpdate]`
-- `get_applications_by_statuses(statuses) -> list[Application]`
+**`FirestoreModel`** (base, `base.py`) — inherited by `Job` and `Application`:
+- `FirestoreModel.get(doc_id) -> Self | None` — fetch by id
+- `instance.save() -> Self` — insert (auto-generated id), populate `self.id`
+- `FirestoreModel.update(doc_id, **fields) -> None` — patch fields
+- `FirestoreModel.count_by_status() -> dict[str, int]` — tally by `status` + `total`
+- `instance.to_doc() -> dict` / `cls.from_doc(doc) -> Self` — (de)serialization hooks
 
-**Profile** (`profile.py`):
-- `get_profile() -> UserProfile | None`
-- `save_profile(profile: UserProfile) -> None`
-- `update_profile_fields(**fields) -> None`
-- `delete_profile() -> None`
+**`Job`** (`job.py`) — inherits `FirestoreModel`, plus:
+- `Job.get(doc_id)`, `job.save()`, `Job.update(doc_id, **fields)`, `Job.count_by_status()`
+- `Job.query(*, status=None, min_score=None, limit=100) -> list[Job]` — ordered by `relevance_score` DESC
+- `Job.add_many(jobs: list[Job]) -> int` — batch write, returns count (mutates each `.id`)
+- `Job.all_urls() -> set[str]` — all existing URLs (for dedup)
+
+**`Application`** (`application.py`) — inherits `FirestoreModel`, plus:
+- `Application.get(doc_id)`, `app.save()`, `Application.update(doc_id, **fields)`, `Application.count_by_status()`
+- `Application.query(*, status=None, limit=100) -> list[Application]` — ordered by `created_at` DESC
+- `Application.by_statuses(statuses: list[ApplicationStatus]) -> list[Application]` — `in` filter
+- `Application.from_doc` migrates the legacy `"draft"` status to `READY_FOR_REVIEW` on read
+
+**`UserProfile`** (`profile.py`) — standalone `BaseModel` (singleton):
+- `UserProfile.get() -> UserProfile | None` — read the singleton doc
+- `profile.save() -> UserProfile` — create or fully replace (sets `updated_at`, `id = "default"`)
+- `UserProfile.update(**fields) -> UserProfile` — patch fields (raises `ValueError` if no profile exists)
+- `UserProfile.delete() -> None`
 
 
 ### Profile (`profile/`)

--- a/src/applybot/models/__init__.py
+++ b/src/applybot/models/__init__.py
@@ -1,68 +1,17 @@
-from applybot.models.application import (
-    Application,
-    ApplicationStatus,
-    ApplicationStatusUpdate,
-    UpdateSource,
-    add_application,
-    add_status_update,
-    count_applications_by_status,
-    get_application,
-    get_applications_by_statuses,
-    get_status_updates,
-    query_applications,
-    update_application,
-)
-from applybot.models.base import get_db, init_db
-from applybot.models.job import (
-    Job,
-    JobSource,
-    JobStatus,
-    add_job,
-    add_jobs,
-    count_jobs_by_status,
-    get_all_job_urls,
-    get_job,
-    query_jobs,
-    update_job,
-)
-from applybot.models.profile import (
-    ContactInfo,
-    UserProfile,
-    delete_profile,
-    get_profile,
-    save_profile,
-    update_profile_fields,
-)
+from applybot.models.application import Application, ApplicationStatus
+from applybot.models.base import FirestoreModel, get_db, init_db
+from applybot.models.job import Job, JobSource, JobStatus
+from applybot.models.profile import ContactInfo, UserProfile
 
 __all__ = [
     "Application",
     "ApplicationStatus",
-    "ApplicationStatusUpdate",
     "ContactInfo",
+    "FirestoreModel",
     "Job",
     "JobSource",
     "JobStatus",
-    "UpdateSource",
     "UserProfile",
-    "add_application",
-    "add_job",
-    "add_jobs",
-    "add_status_update",
-    "count_applications_by_status",
-    "count_jobs_by_status",
-    "delete_profile",
-    "get_all_job_urls",
-    "get_application",
-    "get_applications_by_statuses",
     "get_db",
-    "get_job",
-    "get_profile",
-    "get_status_updates",
     "init_db",
-    "query_applications",
-    "query_jobs",
-    "save_profile",
-    "update_application",
-    "update_job",
-    "update_profile_fields",
 ]

--- a/src/applybot/models/application.py
+++ b/src/applybot/models/application.py
@@ -1,4 +1,9 @@
-"""Application and status update models with Firestore CRUD operations."""
+"""Application model with Firestore CRUD operations.
+
+``Application`` inherits :class:`~applybot.models.base.FirestoreModel` for
+document-level CRUD (``get``/``save``/``update``/``count_by_status``);
+application-specific query helpers live as classmethods on the model.
+"""
 
 from __future__ import annotations
 
@@ -7,12 +12,9 @@ from datetime import UTC, datetime
 from typing import Any
 
 from google.cloud.firestore_v1.base_query import FieldFilter
-from pydantic import BaseModel, Field
+from pydantic import Field
 
-from applybot.models.base import get_db
-
-COLLECTION = "applications"
-STATUS_UPDATES_COLLECTION = "application_status_updates"
+from applybot.models.base import FirestoreModel
 
 
 class ApplicationStatus(str, enum.Enum):
@@ -26,15 +28,12 @@ class ApplicationStatus(str, enum.Enum):
     WITHDRAWN = "withdrawn"
 
 
-class UpdateSource(str, enum.Enum):
-    MANUAL = "manual"
-    SYSTEM = "system"
-
-
-class Application(BaseModel):
+class Application(FirestoreModel):
     """Job application stored in Firestore."""
 
-    id: str = ""
+    COLLECTION = "applications"
+    ENUM_FIELDS = ("status",)
+
     job_id: str = ""
     tailored_resume_path: str = ""
     cover_letter: str = ""
@@ -47,144 +46,42 @@ class Application(BaseModel):
     def __repr__(self) -> str:
         return f"<Application {self.id}: job={self.job_id} status={self.status.value}>"
 
+    @classmethod
+    def from_doc(cls, doc: Any) -> Application:
+        """Build an Application from a Firestore snapshot.
 
-class ApplicationStatusUpdate(BaseModel):
-    """Audit trail entry for application status changes."""
+        Migrates the legacy ``"draft"`` status (removed from the enum) to
+        ``READY_FOR_REVIEW`` on read.
+        """
+        data = doc.to_dict()
+        if data.get("status") == "draft":
+            data["status"] = ApplicationStatus.READY_FOR_REVIEW.value
+        return cls(id=doc.id, **data)
 
-    id: str = ""
-    application_id: str = ""
-    status: ApplicationStatus
-    source: UpdateSource
-    details: str = ""
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    # -- application-specific helpers ----------------------------------------
+    @classmethod
+    def query(
+        cls,
+        *,
+        status: ApplicationStatus | None = None,
+        limit: int = 100,
+    ) -> list[Application]:
+        """Query applications with optional status filter. Ordered by created_at desc."""
+        query = cls._collection().order_by("created_at", direction="DESCENDING")
+        if status is not None:
+            query = query.where(filter=FieldFilter("status", "==", status.value))
+        query = query.limit(limit)
+        return [cls.from_doc(doc) for doc in query.stream()]
 
-    def __repr__(self) -> str:
-        return f"<StatusUpdate {self.id}: {self.status.value} via {self.source.value}>"
-
-
-def _app_to_doc(app: Application) -> dict[str, Any]:
-    """Convert an Application to a Firestore-compatible dict."""
-    data = app.model_dump(exclude={"id"})
-    data["status"] = (
-        data["status"].value
-        if isinstance(data["status"], ApplicationStatus)
-        else data["status"]
-    )
-    return data
-
-
-def _doc_to_app(doc: Any) -> Application:
-    """Convert a Firestore document snapshot to an Application."""
-    data = doc.to_dict()
-    # Migrate legacy "draft" status — removed from enum, treat as ready_for_review
-    if data.get("status") == "draft":
-        data["status"] = ApplicationStatus.READY_FOR_REVIEW.value
-    return Application(id=doc.id, **data)
-
-
-def _update_to_doc(update: ApplicationStatusUpdate) -> dict[str, Any]:
-    """Convert an ApplicationStatusUpdate to a Firestore-compatible dict."""
-    data = update.model_dump(exclude={"id"})
-    data["status"] = (
-        data["status"].value
-        if isinstance(data["status"], ApplicationStatus)
-        else data["status"]
-    )
-    data["source"] = (
-        data["source"].value
-        if isinstance(data["source"], UpdateSource)
-        else data["source"]
-    )
-    return data
-
-
-def _doc_to_update(doc: Any) -> ApplicationStatusUpdate:
-    """Convert a Firestore document to an ApplicationStatusUpdate."""
-    data = doc.to_dict()
-    return ApplicationStatusUpdate(id=doc.id, **data)
-
-
-def get_application(app_id: str) -> Application | None:
-    """Get an application by document ID."""
-    doc = get_db().collection(COLLECTION).document(app_id).get()
-    if not doc.exists:
-        return None
-    return _doc_to_app(doc)
-
-
-def add_application(app: Application) -> Application:
-    """Add a new application. Returns with ID populated."""
-    data = _app_to_doc(app)
-    _, ref = get_db().collection(COLLECTION).add(data)
-    app.id = ref.id
-    return app
-
-
-def update_application(app_id: str, **fields: Any) -> None:
-    """Update specific fields on an application document."""
-    # Convert enum values
-    if "status" in fields and hasattr(fields["status"], "value"):
-        fields["status"] = fields["status"].value
-    get_db().collection(COLLECTION).document(app_id).update(fields)
-
-
-def query_applications(
-    *,
-    status: ApplicationStatus | None = None,
-    limit: int = 100,
-) -> list[Application]:
-    """Query applications with optional status filter. Ordered by created_at desc."""
-    ref = get_db().collection(COLLECTION)
-    query = ref.order_by("created_at", direction="DESCENDING")
-    if status is not None:
-        query = query.where(filter=FieldFilter("status", "==", status.value))
-    query = query.limit(limit)
-    return [_doc_to_app(doc) for doc in query.stream()]
-
-
-def count_applications_by_status() -> dict[str, int]:
-    """Count applications grouped by status."""
-    counts: dict[str, int] = {}
-    total = 0
-    for doc in get_db().collection(COLLECTION).select(["status"]).stream():
-        status = doc.to_dict().get("status", "unknown")
-        counts[status] = counts.get(status, 0) + 1
-        total += 1
-    counts["total"] = total
-    return counts
-
-
-def add_status_update(update: ApplicationStatusUpdate) -> ApplicationStatusUpdate:
-    """Add a status update record."""
-    data = _update_to_doc(update)
-    _, ref = get_db().collection(STATUS_UPDATES_COLLECTION).add(data)
-    update.id = ref.id
-    return update
-
-
-def get_status_updates(app_id: str) -> list[ApplicationStatusUpdate]:
-    """Get all status updates for an application."""
-    docs = (
-        get_db()
-        .collection(STATUS_UPDATES_COLLECTION)
-        .where(filter=FieldFilter("application_id", "==", app_id))
-        .order_by("timestamp")
-        .stream()
-    )
-    return [_doc_to_update(doc) for doc in docs]
-
-
-def get_applications_by_statuses(
-    statuses: list[ApplicationStatus],
-) -> list[Application]:
-    """Get applications matching any of the given statuses."""
-    if not statuses:
-        return []
-    status_values = [s.value for s in statuses]
-    docs = (
-        get_db()
-        .collection(COLLECTION)
-        .where(filter=FieldFilter("status", "in", status_values))
-        .stream()
-    )
-    return [_doc_to_app(doc) for doc in docs]
+    @classmethod
+    def by_statuses(cls, statuses: list[ApplicationStatus]) -> list[Application]:
+        """Return applications matching any of the given statuses."""
+        if not statuses:
+            return []
+        status_values = [s.value for s in statuses]
+        docs = (
+            cls._collection()
+            .where(filter=FieldFilter("status", "in", status_values))
+            .stream()
+        )
+        return [cls.from_doc(doc) for doc in docs]

--- a/src/applybot/models/base.py
+++ b/src/applybot/models/base.py
@@ -1,25 +1,141 @@
-"""Firestore client management — lazy singleton."""
+"""Firestore client management and the base model for Firestore-backed documents.
+
+This module provides two things:
+
+* :func:`get_db` — a process-wide cached Firestore client.
+* :class:`FirestoreModel` — a :class:`pydantic.BaseModel` mixin that gives
+  subclasses document-level CRUD (``get``/``save``/``update``/
+  ``count_by_status``) against a single Firestore collection of auto-ID
+  documents.
+"""
 
 from __future__ import annotations
 
+from functools import lru_cache
+from typing import Any, ClassVar, Self
+
 from google.cloud.firestore_v1 import Client
+from pydantic import BaseModel
 
 from applybot.config import settings
 
-_client: Client | None = None
 
-
+@lru_cache(maxsize=1)
 def get_db() -> Client:
-    """Return the Firestore client singleton (lazy-initialized)."""
-    global _client
-    if _client is None:
-        kwargs = {}
-        if settings.gcp_project_id:
-            kwargs["project"] = settings.gcp_project_id
-        _client = Client(**kwargs)
-    return _client
+    """Return the Firestore client singleton, lazily built and cached.
+
+    The client is cached for the process lifetime via :func:`functools.lru_cache`;
+    every subsequent call returns the same :class:`~google.cloud.firestore_v1.Client`
+    without re-resolving credentials or project. Construction honors the
+    standard Firestore environment:
+
+    * ``FIRESTORE_EMULATOR_HOST`` — when set (e.g. ``localhost:8080``) the client
+      targets the local emulator; used by the test suite.
+    * ``GOOGLE_CLOUD_PROJECT`` / ``settings.gcp_project_id`` — the project id
+      passed to the client.
+    * Otherwise Application Default Credentials are used.
+
+    To force re-initialization (e.g. between tests that swap the emulator in
+    and out), call ``get_db.cache_clear()``.
+    """
+    kwargs: dict[str, Any] = {}
+    if settings.gcp_project_id:
+        kwargs["project"] = settings.gcp_project_id
+    return Client(**kwargs)
 
 
 def init_db() -> None:
-    """Verify Firestore connection. No schema needed (schema-less)."""
+    """Eagerly construct the Firestore client.
+
+    Firestore is schema-less, so there is no migration to run. This forces
+    client construction (and thus project/credential resolution) at startup so
+    misconfiguration surfaces immediately rather than on the first query. It
+    does **not** perform a network round-trip — the :class:`Client` is lazy and
+    only contacts Firestore on the first request.
+    """
     get_db()
+
+
+class FirestoreModel(BaseModel):
+    """Pydantic model backed by a Firestore collection of auto-ID documents.
+
+    Subclasses declare two class vars:
+
+    * ``COLLECTION`` — the Firestore collection name.
+    * ``ENUM_FIELDS`` — model field names whose enum values must be serialized
+      to plain strings on write (Firestore stores enums as their ``.value``).
+
+    Override :meth:`to_doc` / :meth:`from_doc` for any extra serialization or
+    legacy-data migration specific to a subclass; be sure to call ``super()``
+    so the base enum coercion and ``id`` handling are preserved.
+    """
+
+    COLLECTION: ClassVar[str] = ""
+    ENUM_FIELDS: ClassVar[tuple[str, ...]] = ()
+
+    id: str = ""
+
+    # -- serialization hooks -------------------------------------------------
+    def to_doc(self) -> dict[str, Any]:
+        """Serialize this document to a Firestore-compatible dict.
+
+        Drops ``id`` (Firestore owns document ids) and coerces every field in
+        ``ENUM_FIELDS`` from its enum member to its plain ``.value`` string.
+        """
+        data = self.model_dump(exclude={"id"})
+        for field in self.ENUM_FIELDS:
+            value = data.get(field)
+            if hasattr(value, "value"):
+                data[field] = getattr(value, "value")
+        return data
+
+    @classmethod
+    def from_doc(cls, doc: Any) -> Self:
+        """Build an instance from a Firestore document snapshot."""
+        return cls(id=doc.id, **doc.to_dict())
+
+    # -- CRUD ----------------------------------------------------------------
+    @classmethod
+    def _collection(cls) -> Any:
+        return get_db().collection(cls.COLLECTION)
+
+    @classmethod
+    def get(cls, doc_id: str) -> Self | None:
+        """Fetch a document by id, or ``None`` if it does not exist."""
+        doc = cls._collection().document(doc_id).get()
+        if not doc.exists:
+            return None
+        return cls.from_doc(doc)
+
+    def save(self) -> Self:
+        """Insert this document and populate ``self.id`` with the generated id.
+
+        This is insert-only; use :meth:`update` to mutate an existing document.
+        """
+        _, ref = self._collection().add(self.to_doc())
+        self.id = ref.id
+        return self
+
+    @classmethod
+    def update(cls, doc_id: str, **fields: Any) -> None:
+        """Patch specific fields on an existing document.
+
+        Enum-valued kwargs in ``ENUM_FIELDS`` are coerced to their ``.value``.
+        """
+        for field in cls.ENUM_FIELDS:
+            value = fields.get(field)
+            if hasattr(value, "value"):
+                fields[field] = getattr(value, "value")
+        cls._collection().document(doc_id).update(fields)
+
+    @classmethod
+    def count_by_status(cls) -> dict[str, int]:
+        """Tally documents grouped by their ``status`` field, plus a ``total``."""
+        counts: dict[str, int] = {}
+        total = 0
+        for doc in cls._collection().select(["status"]).stream():
+            status = doc.to_dict().get("status", "unknown")
+            counts[status] = counts.get(status, 0) + 1
+            total += 1
+        counts["total"] = total
+        return counts

--- a/src/applybot/models/job.py
+++ b/src/applybot/models/job.py
@@ -1,4 +1,9 @@
-"""Job model and Firestore CRUD operations."""
+"""Job model and Firestore CRUD operations.
+
+``Job`` inherits :class:`~applybot.models.base.FirestoreModel` for document-level
+CRUD (``get``/``save``/``update``/``count_by_status``); job-specific batch and
+query helpers live as classmethods on the model itself.
+"""
 
 from __future__ import annotations
 
@@ -7,11 +12,10 @@ from datetime import UTC, date, datetime
 from typing import Any
 
 from google.cloud.firestore_v1.base_query import FieldFilter
-from pydantic import BaseModel, Field
+from pydantic import Field
 
-from applybot.models.base import get_db
-
-COLLECTION = "jobs"
+from applybot.models import base
+from applybot.models.base import FirestoreModel
 
 
 class JobStatus(str, enum.Enum):
@@ -31,10 +35,12 @@ class JobSource(str, enum.Enum):
     MANUAL = "manual"
 
 
-class Job(BaseModel):
+class Job(FirestoreModel):
     """Job listing stored in Firestore."""
 
-    id: str = ""
+    COLLECTION = "jobs"
+    ENUM_FIELDS = ("status", "source")
+
     title: str
     company: str
     location: str = ""
@@ -52,112 +58,64 @@ class Job(BaseModel):
     def __repr__(self) -> str:
         return f"<Job {self.id}: {self.title} @ {self.company}>"
 
+    def to_doc(self) -> dict[str, Any]:
+        """Serialize to a Firestore dict, coercing ``posted_date`` to ISO."""
+        data = super().to_doc()
+        # Firestore has no native date type — store posted_date as an ISO string.
+        posted = data.get("posted_date")
+        data["posted_date"] = posted.isoformat() if posted is not None else None
+        return data
 
-def _doc_to_job(doc: Any) -> Job:
-    """Convert a Firestore document snapshot to a Job."""
-    data = doc.to_dict()
-    # Convert posted_date from ISO string back to date
-    if "posted_date" in data and isinstance(data["posted_date"], str):
-        data["posted_date"] = date.fromisoformat(data["posted_date"])
-    return Job(id=doc.id, **data)
+    @classmethod
+    def from_doc(cls, doc: Any) -> Job:
+        """Build a Job from a Firestore snapshot, parsing ``posted_date``."""
+        data = doc.to_dict()
+        if "posted_date" in data and isinstance(data["posted_date"], str):
+            data["posted_date"] = date.fromisoformat(data["posted_date"])
+        return cls(id=doc.id, **data)
 
+    # -- job-specific helpers ------------------------------------------------
+    @classmethod
+    def add_many(cls, jobs: list[Job]) -> int:
+        """Batch-add jobs to Firestore. Returns count of jobs added.
 
-def get_job(job_id: str) -> Job | None:
-    """Get a job by document ID."""
-    doc = get_db().collection(COLLECTION).document(job_id).get()
-    if not doc.exists:
-        return None
-    return _doc_to_job(doc)
-
-
-def _job_to_doc(job: Job) -> dict[str, Any]:
-    """Convert a Job to a Firestore-compatible dict."""
-    data = job.model_dump(exclude={"id"})
-    # Convert enums to values
-    data["source"] = (
-        data["source"].value
-        if isinstance(data["source"], JobSource)
-        else data["source"]
-    )
-    data["status"] = (
-        data["status"].value
-        if isinstance(data["status"], JobStatus)
-        else data["status"]
-    )
-    # Convert date to ISO string (Firestore has no native date type)
-    if data.get("posted_date") is not None:
-        data["posted_date"] = data["posted_date"].isoformat()
-    else:
-        data["posted_date"] = None
-    return data
-
-
-def add_job(job: Job) -> Job:
-    """Add a new job to Firestore. Returns the job with its generated ID."""
-    data = _job_to_doc(job)
-    _, ref = get_db().collection(COLLECTION).add(data)
-    job.id = ref.id
-    return job
-
-
-def add_jobs(jobs: list[Job]) -> int:
-    """Batch-add jobs to Firestore. Returns count of jobs added."""
-    db = get_db()
-    batch = db.batch()
-    count = 0
-    for job in jobs:
-        ref = db.collection(COLLECTION).document()
-        batch.set(ref, _job_to_doc(job))
-        job.id = ref.id
-        count += 1
-        # Firestore batches limited to 500 writes
-        if count % 400 == 0:
+        Each job's ``id`` is populated in place with its generated document id.
+        """
+        db = base.get_db()
+        batch = db.batch()
+        count = 0
+        for job in jobs:
+            ref = db.collection(cls.COLLECTION).document()
+            batch.set(ref, job.to_doc())
+            job.id = ref.id
+            count += 1
+            # Firestore batches limited to 500 writes
+            if count % 400 == 0:
+                batch.commit()
+                batch = db.batch()
+        if count % 400 != 0:
             batch.commit()
-            batch = db.batch()
-    if count % 400 != 0:
-        batch.commit()
-    return count
+        return count
 
+    @classmethod
+    def query(
+        cls,
+        *,
+        status: JobStatus | None = None,
+        min_score: float | None = None,
+        limit: int = 100,
+    ) -> list[Job]:
+        """Query jobs with optional filters. Ordered by relevance_score desc."""
+        query = cls._collection().order_by("relevance_score", direction="DESCENDING")
+        if status is not None:
+            query = query.where(filter=FieldFilter("status", "==", status.value))
+        if min_score is not None:
+            query = query.where(filter=FieldFilter("relevance_score", ">=", min_score))
+        query = query.limit(limit)
+        return [cls.from_doc(doc) for doc in query.stream()]
 
-def update_job(job_id: str, **fields: Any) -> None:
-    """Update specific fields on a job document."""
-    # Convert enum values
-    for key in ("status", "source"):
-        if key in fields and hasattr(fields[key], "value"):
-            fields[key] = fields[key].value
-    get_db().collection(COLLECTION).document(job_id).update(fields)
-
-
-def query_jobs(
-    *,
-    status: JobStatus | None = None,
-    min_score: float | None = None,
-    limit: int = 100,
-) -> list[Job]:
-    """Query jobs with optional filters. Ordered by relevance_score descending."""
-    ref = get_db().collection(COLLECTION)
-    query = ref.order_by("relevance_score", direction="DESCENDING")
-    if status is not None:
-        query = query.where(filter=FieldFilter("status", "==", status.value))
-    if min_score is not None:
-        query = query.where(filter=FieldFilter("relevance_score", ">=", min_score))
-    query = query.limit(limit)
-    return [_doc_to_job(doc) for doc in query.stream()]
-
-
-def get_all_job_urls() -> set[str]:
-    """Get all existing job URLs (for deduplication)."""
-    docs = get_db().collection(COLLECTION).select(["url"]).stream()
-    return {doc.to_dict()["url"] for doc in docs}
-
-
-def count_jobs_by_status() -> dict[str, int]:
-    """Count jobs grouped by status."""
-    counts: dict[str, int] = {}
-    total = 0
-    for doc in get_db().collection(COLLECTION).select(["status"]).stream():
-        status = doc.to_dict().get("status", "unknown")
-        counts[status] = counts.get(status, 0) + 1
-        total += 1
-    counts["total"] = total
-    return counts
+    @classmethod
+    def all_urls(cls) -> set[str]:
+        """Return all existing job URLs (for deduplication)."""
+        docs = cls._collection().select(["url"]).stream()
+        return {doc.to_dict()["url"] for doc in docs}

--- a/src/applybot/models/profile.py
+++ b/src/applybot/models/profile.py
@@ -1,18 +1,21 @@
-"""User profile model and Firestore CRUD operations."""
+"""User profile model and Firestore CRUD operations.
+
+``UserProfile`` does **not** inherit :class:`~applybot.models.base.FirestoreModel`:
+it is a singleton document (fixed id ``"default"``, replace-on-save, no auto-id)
+which does not fit the auto-ID collection shape the base class assumes. It keeps
+its own classmethods and reaches the client via ``base.get_db()`` (the module
+attribute, not a bound import) so test patching of ``applybot.models.base.get_db``
+covers it too.
+"""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, ClassVar
 
 from pydantic import BaseModel, Field
 
-from applybot.models.base import get_db
-
-COLLECTION = "profiles"
-
-# We use a well-known document ID for the singleton profile
-PROFILE_DOC_ID = "default"
+from applybot.models import base
 
 
 class ContactInfo(BaseModel):
@@ -25,7 +28,11 @@ class ContactInfo(BaseModel):
 
 
 class UserProfile(BaseModel):
-    """User profile stored in Firestore."""
+    """User profile stored in Firestore as a singleton document."""
+
+    COLLECTION: ClassVar[str] = "profiles"
+    # Well-known document id for the singleton profile.
+    DOC_ID: ClassVar[str] = "default"
 
     id: str = ""
     name: str
@@ -42,57 +49,67 @@ class UserProfile(BaseModel):
     def __repr__(self) -> str:
         return f"<UserProfile {self.id}: {self.name}>"
 
+    # -- serialization hooks -------------------------------------------------
+    @staticmethod
+    def _to_doc(profile: UserProfile) -> dict[str, Any]:
+        """Convert a UserProfile to a Firestore-compatible dict."""
+        return profile.model_dump(exclude={"id"})
 
-def _profile_to_doc(profile: UserProfile) -> dict[str, Any]:
-    """Convert a UserProfile to a Firestore-compatible dict."""
-    return profile.model_dump(exclude={"id"})
+    @classmethod
+    def _from_doc(cls, doc: Any) -> UserProfile:
+        """Convert a Firestore document snapshot to a UserProfile.
 
+        Migrates the legacy flat ``email`` field into the nested ``contact_info``
+        object.
+        """
+        data = doc.to_dict()
+        if "email" in data and "contact_info" not in data:
+            data["contact_info"] = {"email": data.pop("email")}
+        elif "email" in data:
+            data.pop("email")
+        return cls(id=doc.id, **data)
 
-def _doc_to_profile(doc: Any) -> UserProfile:
-    """Convert a Firestore document snapshot to a UserProfile."""
-    data = doc.to_dict()
-    # Migrate legacy flat 'email' field into the nested contact_info object.
-    if "email" in data and "contact_info" not in data:
-        data["contact_info"] = {"email": data.pop("email")}
-    elif "email" in data:
-        data.pop("email")
-    return UserProfile(id=doc.id, **data)
+    # -- CRUD ----------------------------------------------------------------
+    @classmethod
+    def _ref(cls) -> Any:
+        return base.get_db().collection(cls.COLLECTION).document(cls.DOC_ID)
 
+    @classmethod
+    def get(cls) -> UserProfile | None:
+        """Get the user profile (singleton), or ``None`` if it does not exist."""
+        doc = cls._ref().get()
+        if not doc.exists:
+            return None
+        return cls._from_doc(doc)
 
-def get_profile() -> UserProfile | None:
-    """Get the user profile (singleton)."""
-    doc = get_db().collection(COLLECTION).document(PROFILE_DOC_ID).get()
-    if not doc.exists:
-        return None
-    return _doc_to_profile(doc)
+    def save(self) -> UserProfile:
+        """Create or fully replace the user profile."""
+        self.updated_at = datetime.now(UTC)
+        base.get_db().collection(self.COLLECTION).document(self.DOC_ID).set(
+            self._to_doc(self)
+        )
+        self.id = self.DOC_ID
+        return self
 
+    @classmethod
+    def update(cls, **fields: Any) -> UserProfile:
+        """Update specific fields on the profile.
 
-def save_profile(profile: UserProfile) -> UserProfile:
-    """Create or fully replace the user profile."""
-    profile.updated_at = datetime.now(UTC)
-    data = _profile_to_doc(profile)
-    get_db().collection(COLLECTION).document(PROFILE_DOC_ID).set(data)
-    profile.id = PROFILE_DOC_ID
-    return profile
+        Raises ``ValueError`` if no profile exists. Serializes nested Pydantic
+        models to dicts for Firestore compatibility, then re-reads and returns.
+        """
+        fields["updated_at"] = datetime.now(UTC)
+        serialized = {
+            k: v.model_dump() if isinstance(v, BaseModel) else v
+            for k, v in fields.items()
+        }
+        ref = cls._ref()
+        if not ref.get().exists:
+            raise ValueError("No profile exists. Create one first.")
+        ref.update(serialized)
+        return cls._from_doc(ref.get())
 
-
-def update_profile_fields(**fields: Any) -> UserProfile:
-    """Update specific fields on the profile. Raises ValueError if no profile exists."""
-    fields["updated_at"] = datetime.now(UTC)
-    # Serialize any nested Pydantic models to dicts for Firestore compatibility.
-    serialized = {
-        k: v.model_dump() if isinstance(v, BaseModel) else v for k, v in fields.items()
-    }
-    ref = get_db().collection(COLLECTION).document(PROFILE_DOC_ID)
-    doc = ref.get()
-    if not doc.exists:
-        raise ValueError("No profile exists. Create one first.")
-    ref.update(serialized)
-    # Re-read and return
-    updated_doc = ref.get()
-    return _doc_to_profile(updated_doc)
-
-
-def delete_profile() -> None:
-    """Delete the user profile (for testing)."""
-    get_db().collection(COLLECTION).document(PROFILE_DOC_ID).delete()
+    @classmethod
+    def delete(cls) -> None:
+        """Delete the user profile (for testing)."""
+        cls._ref().delete()

--- a/src/applybot/models/tests/firestore_emulator.md
+++ b/src/applybot/models/tests/firestore_emulator.md
@@ -53,7 +53,7 @@ The test suite relies on pytest fixtures located in `tests/conftest.py` to enfor
 When configuring or updating `conftest.py`, ensure the following elements are present:
 
 - **Environment Override:** `FIRESTORE_EMULATOR_HOST` must be set before the Firestore client is initialized.
-- **Dependency Injection:** The `get_db()` function must be patched exactly where it is used (`applybot.models.applications`), not where it is defined (`applybot.models.base`).
+- **Dependency Injection:** The `get_db()` function must be patched at its single definition site (`applybot.models.base.get_db`) — all model access (via `FirestoreModel` classmethods and `UserProfile` classmethods) routes through it. Call `get_db.cache_clear()` so no previously-cached real client leaks in.
 - **State Teardown:** The emulator must be wiped clean after every test using its REST API.
 
 ```python
@@ -78,8 +78,11 @@ def db_client():
 @pytest.fixture(autouse=True)
 def mock_get_db(db_client):
     """Hooks into the application's DB getter to use the test client."""
-    # NOTE: We patch where get_db is imported/used, not where it is defined.
-    with patch("applybot.models.applications.get_db", return_value=db_client):
+    # NOTE: get_db is lru_cached; clear the cache and patch the single definition
+    # site so every FirestoreModel / UserProfile classmethod sees the test client.
+    from applybot.models import base
+    base.get_db.cache_clear()
+    with patch("applybot.models.base.get_db", return_value=db_client):
         yield db_client
 
 
@@ -97,21 +100,21 @@ def clear_emulator():
 When writing or modifying tests, adhere to the following rules:
 
 - **Assume an Empty Database:** Because of the `clear_emulator` fixture, every test starts with 0 documents. You must seed any necessary state in the _Given_ phase of your test.
-- **Test Serialization Boundaries:** Pydantic models (like `Application`) and Firestore documents are distinct. Always verify that `Enum`s and `Datetime`s correctly convert to strings/timestamps when passing through `_app_to_doc` and `_doc_to_app`.
-- **Bypass Pydantic for Legacy Data Tests:** If testing migration logic (e.g., handling deprecated statuses like `"draft"`), inject raw dictionaries directly into Firestore using the `db_client` fixture, rather than using the application's `add_application` function.
+- **Test Serialization Boundaries:** Pydantic models (like `Application`) and Firestore documents are distinct. Always verify that `Enum`s and `Datetime`s correctly convert to strings/timestamps when passing through `Application.to_doc()` and `Application.from_doc()`.
+- **Bypass Pydantic for Legacy Data Tests:** If testing migration logic (e.g., handling deprecated statuses like `"draft"`), inject raw dictionaries directly into Firestore using the `db_client` fixture, rather than using the model's `save()` classmethod.
 
 ### Example Test Structure
 
 ```python
 def test_create_and_fetch_application(db_client):
     # 1. Given (Seed data)
-    from applybot.models.applications import Application, add_application, get_application
+    from applybot.models.application import Application
     app = Application(job_id="job_abc")
 
     # 2. When (Action)
-    saved_app = add_application(app)
+    saved_app = app.save()
 
     # 3. Then (Assertion)
-    fetched_app = get_application(saved_app.id)
+    fetched_app = Application.get(saved_app.id)
     assert fetched_app.job_id == "job_abc"
 ```

--- a/src/applybot/models/tests/test_application.py
+++ b/src/applybot/models/tests/test_application.py
@@ -8,22 +8,9 @@ from typing import Any
 from applybot.models.application import (
     Application,
     ApplicationStatus,
-    ApplicationStatusUpdate,
-    UpdateSource,
-    _app_to_doc,
-    _doc_to_app,
-    add_application,
-    add_status_update,
-    count_applications_by_status,
-    get_application,
-    get_applications_by_statuses,
-    get_status_updates,
-    query_applications,
-    update_application,
 )
 
 APPLICATIONS_COLLECTION = "applications"
-STATUS_UPDATES_COLLECTION = "application_status_updates"
 
 
 # ---------------------------------------------------------------------------
@@ -41,17 +28,6 @@ def _make_app(**overrides: Any) -> Application:
     }
     defaults.update(overrides)
     return Application(**defaults)
-
-
-def _make_update(**overrides: Any) -> ApplicationStatusUpdate:
-    defaults: dict[str, Any] = {
-        "application_id": "app_xyz",
-        "status": ApplicationStatus.APPROVED,
-        "source": UpdateSource.SYSTEM,
-        "details": "auto-approved",
-    }
-    defaults.update(overrides)
-    return ApplicationStatusUpdate(**defaults)
 
 
 # ---------------------------------------------------------------------------
@@ -76,22 +52,6 @@ class TestApplicationModel:
         assert repr(app) == "<Application : job=job_abc status=ready_for_review>"
 
 
-class TestStatusUpdateModel:
-    def test_defaults(self):
-        update = ApplicationStatusUpdate(
-            application_id="app_1",
-            status=ApplicationStatus.SUBMITTED,
-            source=UpdateSource.MANUAL,
-        )
-        assert update.id == ""
-        assert update.details == ""
-        assert isinstance(update.timestamp, datetime)
-
-    def test_repr(self):
-        update = _make_update()
-        assert repr(update) == "<StatusUpdate : approved via system>"
-
-
 # ---------------------------------------------------------------------------
 # Serialization
 # ---------------------------------------------------------------------------
@@ -109,7 +69,7 @@ class _StubDoc:
 class TestApplicationSerialization:
     def test_status_enum_serialized_to_value(self):
         app = _make_app(status=ApplicationStatus.OFFER)
-        doc = _app_to_doc(app)
+        doc = app.to_doc()
         assert doc["status"] == ApplicationStatus.OFFER.value
         assert type(doc["status"]) is str
         assert "id" not in doc
@@ -120,7 +80,7 @@ class TestApplicationSerialization:
             answers={"q1": "a1", "q2": "a2"},
             profile_gaps=[{"requirement": "X"}],
         )
-        roundtripped = _doc_to_app(_StubDoc(_app_to_doc(app)))
+        roundtripped = Application.from_doc(_StubDoc(app.to_doc()))
         assert roundtripped.status == ApplicationStatus.SUBMITTED
         assert roundtripped.answers == {"q1": "a1", "q2": "a2"}
         assert roundtripped.profile_gaps == [{"requirement": "X"}]
@@ -129,7 +89,7 @@ class TestApplicationSerialization:
         app = _make_app()
         ts = datetime(2025, 7, 19, 12, 0, tzinfo=UTC)
         app.created_at = ts
-        roundtripped = _doc_to_app(_StubDoc(_app_to_doc(app)))
+        roundtripped = Application.from_doc(_StubDoc(app.to_doc()))
         assert roundtripped.created_at.replace(microsecond=0) == ts.replace(
             microsecond=0
         )
@@ -138,15 +98,31 @@ class TestApplicationSerialization:
         app = _make_app()
         ts = datetime(2025, 7, 19, 14, 30, tzinfo=UTC)
         app.submitted_at = ts
-        roundtripped = _doc_to_app(_StubDoc(_app_to_doc(app)))
+        roundtripped = Application.from_doc(_StubDoc(app.to_doc()))
         assert roundtripped.submitted_at is not None
         assert roundtripped.submitted_at.replace(microsecond=0) == ts.replace(
             microsecond=0
         )
 
+    def test_legacy_draft_status_migrated_to_ready_for_review(self):
+        """Legacy "draft" status (removed from enum) is migrated on read via from_doc."""
+        stub = _StubDoc(
+            {
+                "job_id": "job_legacy",
+                "status": "draft",
+                "cover_letter": "",
+                "answers": {},
+                "profile_gaps": [],
+                "created_at": datetime.now(UTC),
+                "submitted_at": None,
+            }
+        )
+        migrated = Application.from_doc(stub)
+        assert migrated.status == ApplicationStatus.READY_FOR_REVIEW
+
 
 # ---------------------------------------------------------------------------
-# Legacy data migration
+# Legacy data migration (emulator-backed)
 # ---------------------------------------------------------------------------
 
 
@@ -168,7 +144,7 @@ class TestApplicationLegacyMigration:
                 "submitted_at": None,
             }
         )
-        migrated = get_application(ref.id)
+        migrated = Application.get(ref.id)
         assert migrated is not None
         assert migrated.status == ApplicationStatus.READY_FOR_REVIEW
 
@@ -179,33 +155,33 @@ class TestApplicationLegacyMigration:
 
 
 class TestApplicationCRUD:
-    def test_add_application_populates_id(self):
+    def test_save_populates_id(self):
         app = _make_app()
         assert app.id == ""
-        saved = add_application(app)
+        saved = app.save()
         assert saved.id != ""
         assert saved is app
 
-    def test_get_application_existing(self):
-        saved = add_application(_make_app(cover_letter="Hi"))
-        fetched = get_application(saved.id)
+    def test_get_existing(self):
+        saved = _make_app(cover_letter="Hi").save()
+        fetched = Application.get(saved.id)
         assert fetched is not None
         assert fetched.cover_letter == "Hi"
 
-    def test_get_application_not_found(self):
-        assert get_application("nonexistent-doc-id") is None
+    def test_get_not_found(self):
+        assert Application.get("nonexistent-doc-id") is None
 
-    def test_update_application_converts_status_enum(self):
-        saved = add_application(_make_app(status=ApplicationStatus.READY_FOR_REVIEW))
-        update_application(saved.id, status=ApplicationStatus.APPROVED)
-        fetched = get_application(saved.id)
+    def test_update_converts_status_enum(self):
+        saved = _make_app(status=ApplicationStatus.READY_FOR_REVIEW).save()
+        Application.update(saved.id, status=ApplicationStatus.APPROVED)
+        fetched = Application.get(saved.id)
         assert fetched is not None
         assert fetched.status == ApplicationStatus.APPROVED
 
-    def test_update_application_partial_fields(self):
-        saved = add_application(_make_app())
-        update_application(saved.id, cover_letter="New letter", answers={"q": "a"})
-        fetched = get_application(saved.id)
+    def test_update_partial_fields(self):
+        saved = _make_app().save()
+        Application.update(saved.id, cover_letter="New letter", answers={"q": "a"})
+        fetched = Application.get(saved.id)
         assert fetched is not None
         assert fetched.cover_letter == "New letter"
         assert fetched.answers == {"q": "a"}
@@ -218,32 +194,32 @@ class TestApplicationCRUD:
 
 
 class TestApplicationQueries:
-    def test_query_applications_status_filter(self):
-        add_application(_make_app(job_id="j1", status=ApplicationStatus.SUBMITTED))
-        add_application(_make_app(job_id="j2", status=ApplicationStatus.OFFER))
-        add_application(_make_app(job_id="j3", status=ApplicationStatus.SUBMITTED))
+    def test_query_status_filter(self):
+        _make_app(job_id="j1", status=ApplicationStatus.SUBMITTED).save()
+        _make_app(job_id="j2", status=ApplicationStatus.OFFER).save()
+        _make_app(job_id="j3", status=ApplicationStatus.SUBMITTED).save()
 
-        results = query_applications(status=ApplicationStatus.SUBMITTED)
+        results = Application.query(status=ApplicationStatus.SUBMITTED)
         assert len(results) == 2
         assert all(a.status == ApplicationStatus.SUBMITTED for a in results)
 
-    def test_query_applications_ordered_by_created_at_desc(self):
+    def test_query_ordered_by_created_at_desc(self):
         old = _make_app(job_id="old")
         old.created_at = datetime(2025, 1, 1, tzinfo=UTC)
-        add_application(old)
+        old.save()
 
         new = _make_app(job_id="new")
         new.created_at = datetime(2025, 7, 19, tzinfo=UTC)
-        add_application(new)
+        new.save()
 
-        results = query_applications()
+        results = Application.query()
         job_ids = [a.job_id for a in results]
         assert job_ids == ["new", "old"]
 
-    def test_query_applications_limit(self):
+    def test_query_limit(self):
         for i in range(5):
-            add_application(_make_app(job_id=f"j{i}"))
-        results = query_applications(limit=2)
+            _make_app(job_id=f"j{i}").save()
+        results = Application.query(limit=2)
         assert len(results) == 2
 
 
@@ -253,62 +229,18 @@ class TestApplicationQueries:
 
 
 class TestApplicationAggregates:
-    def test_count_applications_by_status(self):
-        add_application(_make_app(status=ApplicationStatus.SUBMITTED))
-        add_application(_make_app(status=ApplicationStatus.SUBMITTED))
-        add_application(_make_app(status=ApplicationStatus.OFFER))
+    def test_count_by_status(self):
+        _make_app(status=ApplicationStatus.SUBMITTED).save()
+        _make_app(status=ApplicationStatus.SUBMITTED).save()
+        _make_app(status=ApplicationStatus.OFFER).save()
 
-        counts = count_applications_by_status()
+        counts = Application.count_by_status()
         assert counts["submitted"] == 2
         assert counts["offer"] == 1
         assert counts["total"] == 3
 
-    def test_count_applications_by_status_empty(self):
-        assert count_applications_by_status() == {"total": 0}
-
-
-# ---------------------------------------------------------------------------
-# Status updates (audit trail)
-# ---------------------------------------------------------------------------
-
-
-class TestStatusUpdates:
-    def test_add_status_update_populates_id(self):
-        update = _make_update()
-        assert update.id == ""
-        saved = add_status_update(update)
-        assert saved.id != ""
-
-    def test_get_status_updates_filtered_by_application(self):
-        app_a = add_application(_make_app())
-        app_b = add_application(_make_app())
-
-        add_status_update(
-            _make_update(application_id=app_a.id, status=ApplicationStatus.APPROVED)
-        )
-        add_status_update(
-            _make_update(application_id=app_b.id, status=ApplicationStatus.REJECTED)
-        )
-
-        results = get_status_updates(app_a.id)
-        assert len(results) == 1
-        assert results[0].status == ApplicationStatus.APPROVED
-
-    def test_get_status_updates_ordered_by_timestamp(self):
-        app = add_application(_make_app())
-        early = _make_update(application_id=app.id, status=ApplicationStatus.APPROVED)
-        early.timestamp = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
-        late = _make_update(application_id=app.id, status=ApplicationStatus.INTERVIEW)
-        late.timestamp = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
-
-        add_status_update(early)
-        add_status_update(late)
-
-        results = get_status_updates(app.id)
-        assert [r.status for r in results] == [
-            ApplicationStatus.APPROVED,
-            ApplicationStatus.INTERVIEW,
-        ]
+    def test_count_by_status_empty(self):
+        assert Application.count_by_status() == {"total": 0}
 
 
 # ---------------------------------------------------------------------------
@@ -318,16 +250,16 @@ class TestStatusUpdates:
 
 class TestApplicationsByStatuses:
     def test_in_query_matches_any_status(self):
-        add_application(_make_app(job_id="j1", status=ApplicationStatus.SUBMITTED))
-        add_application(_make_app(job_id="j2", status=ApplicationStatus.OFFER))
-        add_application(_make_app(job_id="j3", status=ApplicationStatus.REJECTED))
+        _make_app(job_id="j1", status=ApplicationStatus.SUBMITTED).save()
+        _make_app(job_id="j2", status=ApplicationStatus.OFFER).save()
+        _make_app(job_id="j3", status=ApplicationStatus.REJECTED).save()
 
-        results = get_applications_by_statuses(
+        results = Application.by_statuses(
             [ApplicationStatus.SUBMITTED, ApplicationStatus.OFFER]
         )
         job_ids = {a.job_id for a in results}
         assert job_ids == {"j1", "j2"}
 
     def test_empty_statuses_returns_empty(self):
-        add_application(_make_app())
-        assert get_applications_by_statuses([]) == []
+        _make_app().save()
+        assert Application.by_statuses([]) == []

--- a/src/applybot/models/tests/test_base.py
+++ b/src/applybot/models/tests/test_base.py
@@ -7,13 +7,14 @@ from applybot.models import base
 
 def test_get_db_returns_singleton():
     """get_db() must return the same Client instance across calls."""
+    base.get_db.cache_clear()  # isolate from any previously-cached client
     first = base.get_db()
     second = base.get_db()
     assert first is second
 
 
 def test_init_db_initializes_client():
-    """init_db() must initialize the client without raising."""
-    base._client = None  # force re-init
+    """init_db() must initialize the cached client without raising."""
+    base.get_db.cache_clear()  # force re-init of the lru_cache singleton
     base.init_db()
-    assert base._client is not None
+    assert base.get_db() is not None

--- a/src/applybot/models/tests/test_job.py
+++ b/src/applybot/models/tests/test_job.py
@@ -8,15 +8,6 @@ from applybot.models.job import (
     Job,
     JobSource,
     JobStatus,
-    _doc_to_job,
-    _job_to_doc,
-    add_job,
-    add_jobs,
-    count_jobs_by_status,
-    get_all_job_urls,
-    get_job,
-    query_jobs,
-    update_job,
 )
 
 # ---------------------------------------------------------------------------
@@ -74,14 +65,14 @@ class TestJobModel:
 
 
 # ---------------------------------------------------------------------------
-# Serialization (_job_to_doc / _doc_to_job)
+# Serialization (Job.to_doc / Job.from_doc)
 # ---------------------------------------------------------------------------
 
 
 class TestJobSerialization:
     def test_enums_serialized_to_string_values(self):
         job = _make_job()
-        doc = _job_to_doc(job)
+        doc = job.to_doc()
         assert doc["source"] == JobSource.SERPAPI.value
         assert doc["status"] == JobStatus.NEW.value
         # id is excluded
@@ -89,12 +80,12 @@ class TestJobSerialization:
 
     def test_posted_date_serialized_to_iso_string(self):
         job = _make_job(posted_date=date(2025, 7, 19))
-        doc = _job_to_doc(job)
+        doc = job.to_doc()
         assert doc["posted_date"] == "2025-07-19"
 
     def test_posted_date_none_serialized_as_none(self):
         job = _make_job(posted_date=None)
-        doc = _job_to_doc(job)
+        doc = job.to_doc()
         assert doc["posted_date"] is None
 
     def test_round_trip(self):
@@ -105,7 +96,7 @@ class TestJobSerialization:
             hard_requirements=["Python", "5+ years"],
             application_questions=["visa?"],
         )
-        roundtripped = _doc_to_job(_StubDoc(_job_to_doc(job)))
+        roundtripped = Job.from_doc(_StubDoc(job.to_doc()))
         assert roundtripped.title == job.title
         assert roundtripped.source == job.source
         assert roundtripped.status == job.status
@@ -118,7 +109,7 @@ class TestJobSerialization:
         job = _make_job()
         ts = datetime(2025, 7, 19, 12, 0, tzinfo=UTC)
         job.discovered_date = ts
-        roundtripped = _doc_to_job(_StubDoc(_job_to_doc(job)))
+        roundtripped = Job.from_doc(_StubDoc(job.to_doc()))
         # Firestore/emulator stores datetimes at microsecond precision; compare
         # at second precision to avoid float-comparison flakiness.
         assert roundtripped.discovered_date.replace(microsecond=0) == ts.replace(
@@ -143,41 +134,41 @@ class _StubDoc:
 
 
 class TestJobCRUD:
-    def test_add_job_populates_id(self):
+    def test_save_populates_id(self):
         job = _make_job()
         assert job.id == ""
-        saved = add_job(job)
+        saved = job.save()
         assert saved.id != ""
         assert saved is job
 
-    def test_get_job_existing(self):
-        saved = add_job(_make_job(title="Backend Eng"))
-        fetched = get_job(saved.id)
+    def test_get_existing(self):
+        saved = _make_job(title="Backend Eng").save()
+        fetched = Job.get(saved.id)
         assert fetched is not None
         assert fetched.title == "Backend Eng"
         assert fetched.source == JobSource.SERPAPI
 
-    def test_get_job_not_found(self):
-        assert get_job("nonexistent-doc-id") is None
+    def test_get_not_found(self):
+        assert Job.get("nonexistent-doc-id") is None
 
-    def test_update_job_converts_status_enum(self):
-        saved = add_job(_make_job(status=JobStatus.NEW))
-        update_job(saved.id, status=JobStatus.APPROVED)
-        fetched = get_job(saved.id)
+    def test_update_converts_status_enum(self):
+        saved = _make_job(status=JobStatus.NEW).save()
+        Job.update(saved.id, status=JobStatus.APPROVED)
+        fetched = Job.get(saved.id)
         assert fetched is not None
         assert fetched.status == JobStatus.APPROVED
 
-    def test_update_job_converts_source_enum(self):
-        saved = add_job(_make_job(source=JobSource.SERPAPI))
-        update_job(saved.id, source=JobSource.GREENHOUSE)
-        fetched = get_job(saved.id)
+    def test_update_converts_source_enum(self):
+        saved = _make_job(source=JobSource.SERPAPI).save()
+        Job.update(saved.id, source=JobSource.GREENHOUSE)
+        fetched = Job.get(saved.id)
         assert fetched is not None
         assert fetched.source == JobSource.GREENHOUSE
 
-    def test_update_job_partial_fields(self):
-        saved = add_job(_make_job())
-        update_job(saved.id, location="Berlin", relevance_score=0.91)
-        fetched = get_job(saved.id)
+    def test_update_partial_fields(self):
+        saved = _make_job().save()
+        Job.update(saved.id, location="Berlin", relevance_score=0.91)
+        fetched = Job.get(saved.id)
         assert fetched is not None
         assert fetched.location == "Berlin"
         assert fetched.relevance_score == 0.91
@@ -186,25 +177,25 @@ class TestJobCRUD:
 
 
 # ---------------------------------------------------------------------------
-# Batch (add_jobs) — exercises the >400 multi-commit path
+# Batch (add_many) — exercises the >400 multi-commit path
 # ---------------------------------------------------------------------------
 
 
 class TestJobBatch:
-    def test_add_jobs_returns_count(self):
+    def test_add_many_returns_count(self):
         jobs = [_make_job(url=f"https://example.com/b{i}") for i in range(5)]
-        count = add_jobs(jobs)
+        count = Job.add_many(jobs)
         assert count == 5
 
-    def test_add_jobs_populates_ids(self):
+    def test_add_many_populates_ids(self):
         jobs = [_make_job(url=f"https://example.com/b{i}") for i in range(3)]
-        add_jobs(jobs)
+        Job.add_many(jobs)
         assert all(j.id != "" for j in jobs)
 
-    def test_add_jobs_over_400_exercises_multi_commit(self, monkeypatch):
-        """add_jobs must flush mid-batch at the 400-write threshold.
+    def test_add_many_over_400_exercises_multi_commit(self, monkeypatch):
+        """add_many must flush mid-batch at the 400-write threshold.
 
-        The Firestore hard limit is 500 writes per batch; add_jobs commits
+        The Firestore hard limit is 500 writes per batch; add_many commits
         every 400 writes to stay safely under it. With n=420 a correct
         implementation commits twice (once at 400, once for the remainder),
         while one that drops the mid-batch commit would commit only once and
@@ -233,17 +224,17 @@ class TestJobBatch:
 
         n = 420
         jobs = [_make_job(url=f"https://example.com/mc{i}") for i in range(n)]
-        count = add_jobs(jobs)
+        count = Job.add_many(jobs)
         assert count == n
         # Confirm they were all actually written by counting URLs.
-        urls = get_all_job_urls()
+        urls = Job.all_urls()
         assert len(urls) == n
         # The 400-th write forces a mid-batch commit, and the remainder is
         # flushed at the end — so a correct implementation commits >= 2 times.
         assert commit_calls >= 2, f"expected multi-commit, got {commit_calls}"
 
-    def test_add_jobs_empty(self):
-        assert add_jobs([]) == 0
+    def test_add_many_empty(self):
+        assert Job.add_many([]) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -252,39 +243,39 @@ class TestJobBatch:
 
 
 class TestJobQueries:
-    def test_query_jobs_status_filter(self):
-        add_job(_make_job(url="u1", status=JobStatus.NEW))
-        add_job(_make_job(url="u2", status=JobStatus.APPROVED))
-        add_job(_make_job(url="u3", status=JobStatus.NEW))
+    def test_query_status_filter(self):
+        _make_job(url="u1", status=JobStatus.NEW).save()
+        _make_job(url="u2", status=JobStatus.APPROVED).save()
+        _make_job(url="u3", status=JobStatus.NEW).save()
 
-        results = query_jobs(status=JobStatus.NEW)
+        results = Job.query(status=JobStatus.NEW)
         assert len(results) == 2
         assert all(j.status == JobStatus.NEW for j in results)
 
-    def test_query_jobs_min_score_filter(self):
-        add_job(_make_job(url="u1", relevance_score=0.9))
-        add_job(_make_job(url="u2", relevance_score=0.3))
-        add_job(_make_job(url="u3", relevance_score=0.7))
+    def test_query_min_score_filter(self):
+        _make_job(url="u1", relevance_score=0.9).save()
+        _make_job(url="u2", relevance_score=0.3).save()
+        _make_job(url="u3", relevance_score=0.7).save()
 
-        results = query_jobs(min_score=0.7)
+        results = Job.query(min_score=0.7)
         scores = sorted(
             j.relevance_score for j in results if j.relevance_score is not None
         )
         assert scores == [0.7, 0.9]
 
-    def test_query_jobs_order_by_score_desc(self):
-        add_job(_make_job(url="u1", relevance_score=0.5))
-        add_job(_make_job(url="u2", relevance_score=0.95))
-        add_job(_make_job(url="u3", relevance_score=0.1))
+    def test_query_order_by_score_desc(self):
+        _make_job(url="u1", relevance_score=0.5).save()
+        _make_job(url="u2", relevance_score=0.95).save()
+        _make_job(url="u3", relevance_score=0.1).save()
 
-        results = query_jobs()
+        results = Job.query()
         scores = [j.relevance_score for j in results if j.relevance_score is not None]
         assert scores == sorted(scores, reverse=True)
 
-    def test_query_jobs_limit(self):
+    def test_query_limit(self):
         for i in range(5):
-            add_job(_make_job(url=f"u{i}", relevance_score=0.1 * i))
-        results = query_jobs(limit=2)
+            _make_job(url=f"u{i}", relevance_score=0.1 * i).save()
+        results = Job.query(limit=2)
         assert len(results) == 2
 
 
@@ -294,25 +285,25 @@ class TestJobQueries:
 
 
 class TestJobAggregates:
-    def test_get_all_job_urls(self):
-        add_job(_make_job(url="https://a.com/1"))
-        add_job(_make_job(url="https://b.com/2"))
-        urls = get_all_job_urls()
+    def test_all_urls(self):
+        _make_job(url="https://a.com/1").save()
+        _make_job(url="https://b.com/2").save()
+        urls = Job.all_urls()
         assert urls == {"https://a.com/1", "https://b.com/2"}
 
-    def test_get_all_job_urls_empty(self):
-        assert get_all_job_urls() == set()
+    def test_all_urls_empty(self):
+        assert Job.all_urls() == set()
 
-    def test_count_jobs_by_status(self):
-        add_job(_make_job(url="u1", status=JobStatus.NEW))
-        add_job(_make_job(url="u2", status=JobStatus.NEW))
-        add_job(_make_job(url="u3", status=JobStatus.APPROVED))
+    def test_count_by_status(self):
+        _make_job(url="u1", status=JobStatus.NEW).save()
+        _make_job(url="u2", status=JobStatus.NEW).save()
+        _make_job(url="u3", status=JobStatus.APPROVED).save()
 
-        counts = count_jobs_by_status()
+        counts = Job.count_by_status()
         assert counts["new"] == 2
         assert counts["approved"] == 1
         assert counts["total"] == 3
 
-    def test_count_jobs_by_status_empty(self):
-        counts = count_jobs_by_status()
+    def test_count_by_status_empty(self):
+        counts = Job.count_by_status()
         assert counts == {"total": 0}

--- a/src/applybot/models/tests/test_profile.py
+++ b/src/applybot/models/tests/test_profile.py
@@ -8,15 +8,8 @@ from typing import Any
 import pytest
 
 from applybot.models.profile import (
-    PROFILE_DOC_ID,
     ContactInfo,
     UserProfile,
-    _doc_to_profile,
-    _profile_to_doc,
-    delete_profile,
-    get_profile,
-    save_profile,
-    update_profile_fields,
 )
 
 PROFILES_COLLECTION = "profiles"
@@ -97,7 +90,7 @@ class _StubDoc:
 class TestProfileSerialization:
     def test_round_trip(self):
         profile = _make_profile()
-        roundtripped = _doc_to_profile(_StubDoc(_profile_to_doc(profile)))
+        roundtripped = UserProfile._from_doc(_StubDoc(UserProfile._to_doc(profile)))
         assert roundtripped.name == profile.name
         assert roundtripped.contact_info.email == "test@example.com"
         assert roundtripped.skills["technical"] == ["Python", "PyTorch", "ROS"]
@@ -118,7 +111,7 @@ class TestProfileSerialization:
             "enrichment_warning": "",
             "updated_at": datetime.now(UTC),
         }
-        profile = _doc_to_profile(_StubDoc(legacy))
+        profile = UserProfile._from_doc(_StubDoc(legacy))
         assert profile.contact_info.email == "legacy@example.com"
 
     def test_nested_contact_info_wins_over_legacy_flat_email(self):
@@ -137,7 +130,7 @@ class TestProfileSerialization:
             "enrichment_warning": "",
             "updated_at": datetime.now(UTC),
         }
-        profile = _doc_to_profile(_StubDoc(legacy))
+        profile = UserProfile._from_doc(_StubDoc(legacy))
         assert profile.contact_info.email == "nested@example.com"
 
 
@@ -147,90 +140,90 @@ class TestProfileSerialization:
 
 
 class TestProfileCRUD:
-    def test_get_profile_when_none(self):
-        assert get_profile() is None
+    def test_get_when_none(self):
+        assert UserProfile.get() is None
 
-    def test_save_profile_create_and_id(self):
+    def test_save_create_and_id(self):
         profile = _make_profile()
         assert profile.id == ""
-        saved = save_profile(profile)
-        assert saved.id == PROFILE_DOC_ID
+        saved = profile.save()
+        assert saved.id == UserProfile.DOC_ID
 
-    def test_save_profile_round_trip(self):
-        save_profile(_make_profile())
-        fetched = get_profile()
+    def test_save_round_trip(self):
+        _make_profile().save()
+        fetched = UserProfile.get()
         assert fetched is not None
         assert fetched.name == "Test User"
         assert fetched.contact_info.email == "test@example.com"
 
-    def test_save_profile_refreshes_updated_at(self):
+    def test_save_refreshes_updated_at(self):
         profile = _make_profile()
         pre_save_ts = profile.updated_at
-        save_profile(profile)
-        fetched = get_profile()
+        profile.save()
+        fetched = UserProfile.get()
         assert fetched is not None
         assert fetched.updated_at > pre_save_ts
 
-    def test_save_profile_full_replace(self):
-        save_profile(_make_profile(name="Original"))
-        save_profile(_make_profile(name="Replaced"))
-        fetched = get_profile()
+    def test_save_full_replace(self):
+        _make_profile(name="Original").save()
+        _make_profile(name="Replaced").save()
+        fetched = UserProfile.get()
         assert fetched is not None
         assert fetched.name == "Replaced"
 
 
 # ---------------------------------------------------------------------------
-# update_profile_fields
+# UserProfile.update
 # ---------------------------------------------------------------------------
 
 
-class TestUpdateProfileFields:
+class TestUserProfileUpdate:
     def test_updates_fields_and_rereads(self):
-        save_profile(_make_profile())
-        updated = update_profile_fields(summary="New summary")
+        _make_profile().save()
+        updated = UserProfile.update(summary="New summary")
         assert updated.summary == "New summary"
         # Confirm persisted
-        persisted = get_profile()
+        persisted = UserProfile.get()
         assert persisted is not None
         assert persisted.summary == "New summary"
 
     def test_sets_updated_at(self):
-        save_profile(_make_profile())
-        before = get_profile()
+        _make_profile().save()
+        before = UserProfile.get()
         assert before is not None
         before_ts = before.updated_at
-        update_profile_fields(summary="x")
-        after = get_profile()
+        UserProfile.update(summary="x")
+        after = UserProfile.get()
         assert after is not None
         assert after.updated_at >= before_ts
 
     def test_serializes_nested_basemodel(self):
         """Passing a ContactInfo (a BaseModel) must be serialized to a dict."""
-        save_profile(_make_profile())
+        _make_profile().save()
         new_contact = ContactInfo(
             email="new@example.com", github="https://github.com/new"
         )
-        updated = update_profile_fields(contact_info=new_contact)
+        updated = UserProfile.update(contact_info=new_contact)
         assert updated.contact_info.email == "new@example.com"
         assert updated.contact_info.github == "https://github.com/new"
 
     def test_raises_when_no_profile_exists(self):
         with pytest.raises(ValueError, match="No profile exists"):
-            update_profile_fields(summary="x")
+            UserProfile.update(summary="x")
 
 
 # ---------------------------------------------------------------------------
-# delete_profile
+# UserProfile.delete
 # ---------------------------------------------------------------------------
 
 
-class TestDeleteProfile:
+class TestUserProfileDelete:
     def test_deletes_existing(self):
-        save_profile(_make_profile())
-        delete_profile()
-        assert get_profile() is None
+        _make_profile().save()
+        UserProfile.delete()
+        assert UserProfile.get() is None
 
     def test_idempotent_on_missing(self):
         # Should not raise when the profile doesn't exist.
-        delete_profile()
-        assert get_profile() is None
+        UserProfile.delete()
+        assert UserProfile.get() is None

--- a/src/applybot/profile/enrichment.py
+++ b/src/applybot/profile/enrichment.py
@@ -13,7 +13,7 @@ import logging
 from pathlib import Path
 
 from applybot.llm.client import get_llm
-from applybot.models.profile import UserProfile, save_profile, update_profile_fields
+from applybot.models.profile import UserProfile
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +105,7 @@ def enrich_profile_with_llm(profile: UserProfile, resume_text: str) -> UserProfi
     if not updated.contact_info.github and profile.contact_info.github:
         updated.contact_info.github = profile.contact_info.github
 
-    save_profile(updated)
+    updated.save()
     logger.info("LLM profile enrichment complete for profile %r", profile.id)
     return updated
 
@@ -127,7 +127,7 @@ async def enrich_profile_with_llm_async(profile: UserProfile, resume_text: str) 
     except Exception:
         logger.exception("LLM profile enrichment failed — profile unchanged")
         try:
-            update_profile_fields(
+            UserProfile.update(
                 enrichment_warning=(
                     "We could not run AI profile enrichment after your resume upload. "
                     "Your profile still includes the standard parsed resume data."

--- a/src/applybot/profile/manager.py
+++ b/src/applybot/profile/manager.py
@@ -7,15 +7,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from applybot.models.profile import (
-    ContactInfo,
-    UserProfile,
-    save_profile,
-    update_profile_fields,
-)
-from applybot.models.profile import (
-    get_profile as _get_profile,
-)
+from applybot.models.profile import ContactInfo, UserProfile
 
 logger = logging.getLogger(__name__)
 
@@ -27,15 +19,15 @@ class ProfileManager:
 
     def get_profile(self) -> UserProfile | None:
         """Return the user profile, or None."""
-        return _get_profile()
+        return UserProfile.get()
 
     def get_or_create_profile(self, name: str = "", email: str = "") -> UserProfile:
         """Return existing profile or create a blank one."""
-        profile = _get_profile()
+        profile = UserProfile.get()
         if profile is not None:
             return profile
         profile = UserProfile(name=name, contact_info=ContactInfo(email=email))
-        return save_profile(profile)
+        return profile.save()
 
     def update_profile(self, **kwargs: Any) -> UserProfile:
         """Update profile fields. Accepts any UserProfile field name."""
@@ -44,25 +36,25 @@ class ProfileManager:
         for key in kwargs:
             if key not in valid_fields:
                 raise ValueError(f"Unknown profile field: {key}")
-        return update_profile_fields(**kwargs)
+        return UserProfile.update(**kwargs)
 
     def get_skills(self) -> dict[str, Any]:
         """Return the skills dict from the profile."""
-        profile = _get_profile()
+        profile = UserProfile.get()
         if profile is None:
             return {}
         return profile.skills or {}
 
     def get_experiences(self) -> list[Any]:
         """Return the experiences list from the profile."""
-        profile = _get_profile()
+        profile = UserProfile.get()
         if profile is None:
             return []
         return profile.experiences or []
 
     def export_profile_json(self, path: Path | None = None) -> Path:
         """Export the profile to a JSON file for easy editing."""
-        profile = _get_profile()
+        profile = UserProfile.get()
         if profile is None:
             raise ValueError("No profile exists.")
         path = path or DATA_DIR / "profile.json"
@@ -88,11 +80,11 @@ class ProfileManager:
         # Deserialize nested contact_info dict into a ContactInfo object.
         if "contact_info" in data and isinstance(data["contact_info"], dict):
             data["contact_info"] = ContactInfo(**data["contact_info"])
-        profile = _get_profile()
+        profile = UserProfile.get()
         if profile is None:
             profile = UserProfile(**data)
         else:
             for key, value in data.items():
                 if hasattr(profile, key) and key != "id":
                     setattr(profile, key, value)
-        return save_profile(profile)
+        return profile.save()

--- a/src/applybot/tracking/README.md
+++ b/src/applybot/tracking/README.md
@@ -17,7 +17,7 @@ from applybot.tracking.tracker import ApplicationTracker
 tracker = ApplicationTracker()
 
 # Update application status (validates transition)
-app = tracker.update_status(app_id, ApplicationStatus.SUBMITTED, source=UpdateSource.MANUAL, details="...")
+app = tracker.update_status(app_id, ApplicationStatus.SUBMITTED)
 # Raises InvalidTransitionError if transition is not allowed
 
 # Query applications
@@ -56,7 +56,7 @@ Email classification maps to: `received`, `rejected`, `interview`, `offer`.
 
 ## Boundaries
 
-- **Depends on**: `models` (Application, ApplicationStatus, ApplicationStatusUpdate), `llm` (Gmail email classification), `config` (Google credentials)
+- **Depends on**: `models` (Application, ApplicationStatus), `llm` (Gmail email classification), `config` (Google credentials)
 - **Does not depend on**: Discovery, Application (prep), Profile, or Dashboard
 - **Used by**: Dashboard (displays status), CLI/scheduler entry points
 - Gmail integration requires Google OAuth2 credentials (setup not yet automated)

--- a/src/applybot/tracking/gmail.py
+++ b/src/applybot/tracking/gmail.py
@@ -10,12 +10,8 @@ from pydantic import BaseModel
 
 from applybot.config import settings
 from applybot.llm.client import get_llm
-from applybot.models.application import (
-    ApplicationStatus,
-    UpdateSource,
-    get_applications_by_statuses,
-)
-from applybot.models.job import get_job
+from applybot.models.application import Application, ApplicationStatus
+from applybot.models.job import Job
 from applybot.tracking.tracker import update_status
 
 logger = logging.getLogger(__name__)
@@ -97,7 +93,7 @@ def _get_gmail_service() -> Any:
 
 def _get_applied_companies() -> list[str]:
     """Get list of companies with submitted applications."""
-    apps = get_applications_by_statuses(
+    apps = Application.by_statuses(
         [
             ApplicationStatus.SUBMITTED,
             ApplicationStatus.RECEIVED,
@@ -105,7 +101,7 @@ def _get_applied_companies() -> list[str]:
     )
     companies: set[str] = set()
     for app in apps:
-        job = get_job(app.job_id)
+        job = Job.get(app.job_id)
         if job:
             companies.add(job.company)
     return list(companies)
@@ -170,10 +166,10 @@ def _process_email(email: dict[str, Any], company: str) -> dict[str, Any] | None
 Company we applied to: {company}
 
 Email:
-From: {email['from']}
-Subject: {email['subject']}
-Date: {email['date']}
-Body: {email['body'][:2000]}
+From: {email["from"]}
+Subject: {email["subject"]}
+Date: {email["date"]}
+Body: {email["body"][:2000]}
 
 Determine:
 1. Is this related to a job application? (automated receipts, rejections, interview invites, offers)
@@ -198,7 +194,7 @@ Determine:
         return None
 
     # Find the matching application
-    apps = get_applications_by_statuses(
+    apps = Application.by_statuses(
         [
             ApplicationStatus.SUBMITTED,
             ApplicationStatus.RECEIVED,
@@ -206,7 +202,7 @@ Determine:
     )
     application = None
     for app in apps:
-        job = get_job(app.job_id)
+        job = Job.get(app.job_id)
         if job and company.lower() in job.company.lower():
             application = app
             break
@@ -216,12 +212,7 @@ Determine:
         return None
 
     try:
-        update_status(
-            application.id,
-            new_status,
-            source=UpdateSource.GMAIL,
-            details=f"Email: {email['subject']} — {result.summary}",
-        )
+        update_status(application.id, new_status)
         return {
             "application_id": application.id,
             "company": company,

--- a/src/applybot/tracking/tracker.py
+++ b/src/applybot/tracking/tracker.py
@@ -6,17 +6,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
-from applybot.models.application import (
-    Application,
-    ApplicationStatus,
-    ApplicationStatusUpdate,
-    UpdateSource,
-    add_status_update,
-    count_applications_by_status,
-    get_application,
-    query_applications,
-    update_application,
-)
+from applybot.models.application import Application, ApplicationStatus
 
 logger = logging.getLogger(__name__)
 
@@ -61,11 +51,9 @@ class InvalidTransitionError(Exception):
 def update_status(
     application_id: str,
     new_status: ApplicationStatus,
-    source: UpdateSource = UpdateSource.MANUAL,
-    details: str = "",
 ) -> Application:
     """Update the status of an application with validation."""
-    application = get_application(application_id)
+    application = Application.get(application_id)
     if application is None:
         raise ValueError(f"Application {application_id} not found")
 
@@ -78,32 +66,21 @@ def update_status(
             f"Valid transitions: {[s.value for s in valid_next]}"
         )
 
-    # Create status update record
-    update = ApplicationStatusUpdate(
-        application_id=application_id,
-        status=new_status,
-        source=source,
-        details=details,
-        timestamp=datetime.now(UTC),
-    )
-    add_status_update(update)
-
     # Update the application
     fields: dict[str, Any] = {"status": new_status}
     if new_status == ApplicationStatus.SUBMITTED:
         fields["submitted_at"] = datetime.now(UTC)
-    update_application(application_id, **fields)
+    Application.update(application_id, **fields)
 
     # Re-read and return
-    application = get_application(application_id)
+    application = Application.get(application_id)
     assert application is not None
 
     logger.info(
-        "Application %s: %s → %s (via %s)",
+        "Application %s: %s → %s",
         application_id,
         current.value,
         new_status.value,
-        source.value,
     )
     return application
 
@@ -113,9 +90,9 @@ def get_applications(
     limit: int = 100,
 ) -> list[Application]:
     """Get applications, optionally filtered by status."""
-    return query_applications(status=status, limit=limit)
+    return Application.query(status=status, limit=limit)
 
 
 def get_summary() -> dict[str, int]:
     """Get a summary count of applications by status."""
-    return count_applications_by_status()
+    return Application.count_by_status()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,11 +233,11 @@ def mock_firestore():
 
     mock_client = MockFirestoreClient()
 
-    with (
-        patch("applybot.models.base._client", mock_client),
-        patch("applybot.models.job.get_db", return_value=mock_client),
-        patch("applybot.models.application.get_db", return_value=mock_client),
-        patch("applybot.models.profile.get_db", return_value=mock_client),
-    ):
+    with patch("applybot.models.base.get_db", return_value=mock_client):
+        # No previously-cached real client may leak in: clear the lru_cache
+        # after the patch is in place so the next get_db() returns our mock.
+        from applybot.models.base import get_db as _get_db
+
+        _get_db.cache_clear()
         yield mock_client
         mock_client.clear()

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -2,13 +2,8 @@
 
 import pytest
 
-from applybot.models.application import (
-    Application,
-    ApplicationStatus,
-    add_application,
-    get_status_updates,
-)
-from applybot.models.job import Job, JobSource, add_job
+from applybot.models.application import Application, ApplicationStatus
+from applybot.models.job import Job, JobSource
 from applybot.tracking.tracker import (
     InvalidTransitionError,
     get_applications,
@@ -27,19 +22,18 @@ def _create_application(
         url=f"https://example.com/job/track-{id(status)}-{status.value}",
         source=JobSource.MANUAL,
     )
-    job = add_job(job)
+    job.save()
 
     app = Application(job_id=job.id, status=status)
-    app = add_application(app)
+    app.save()
     return app.id
 
 
 class TestStatusTransitions:
     def test_valid_ready_to_withdrawn(self):
         app_id = _create_application(ApplicationStatus.READY_FOR_REVIEW)
-        from applybot.models.application import UpdateSource
 
-        app = update_status(app_id, ApplicationStatus.WITHDRAWN, UpdateSource.MANUAL)
+        app = update_status(app_id, ApplicationStatus.WITHDRAWN)
         assert app.status == ApplicationStatus.WITHDRAWN
 
     def test_valid_ready_to_approved(self):
@@ -55,11 +49,8 @@ class TestStatusTransitions:
 
     def test_valid_submitted_to_rejected(self):
         app_id = _create_application(ApplicationStatus.SUBMITTED)
-        from applybot.models.application import UpdateSource
 
-        app = update_status(
-            app_id, ApplicationStatus.REJECTED, UpdateSource.GMAIL, "Rejection email"
-        )
+        app = update_status(app_id, ApplicationStatus.REJECTED)
         assert app.status == ApplicationStatus.REJECTED
 
     def test_valid_submitted_to_interview(self):
@@ -85,17 +76,6 @@ class TestStatusTransitions:
     def test_nonexistent_application(self):
         with pytest.raises(ValueError, match="not found"):
             update_status("nonexistent_id", ApplicationStatus.APPROVED)
-
-    def test_status_update_creates_record(self):
-        app_id = _create_application(ApplicationStatus.READY_FOR_REVIEW)
-        from applybot.models.application import UpdateSource
-
-        update_status(app_id, ApplicationStatus.APPROVED, UpdateSource.SYSTEM, "Test")
-
-        updates = get_status_updates(app_id)
-        assert len(updates) == 1
-        assert updates[0].status == ApplicationStatus.APPROVED
-        assert updates[0].details == "Test"
 
 
 class TestGetApplications:


### PR DESCRIPTION
- base.py: replace global _client with @lru_cache get_db(); add FirestoreModel base class (get/save/update/count_by_status/to_doc/ from_doc) inherited by Job and Application.
- Drop ApplicationStatusUpdate/UpdateSource audit-trail model and its CRUD; tracker.update_status loses source/details params.
- UserProfile keeps own classmethods (singleton-doc pattern); reaches client via base.get_db() so a single test patch site covers it (same pattern in Job.add_many).
- Migrate all callers to classmethods (clean cutover, no wrappers); ProfileManager instance methods preserved.
- Update tests (models suite, root conftest mock fixture, test_tracking) and docs (models/tracking READMEs, emulator guide).