### PR TITLE
Rework LLM API key access: Secret Manager volume mounts replace TTL/env hybrid

### DIFF
--- a/infra/cloud_functions.tf
+++ b/infra/cloud_functions.tf
@@ -70,6 +70,19 @@ resource "google_cloudfunctions2_function" "discovery" {
       secret     = google_secret_manager_secret.serpapi_key.secret_id
       version    = "latest"
     }
+
+    # Provider API keys as volume mounts (not env vars): the runtime refreshes
+    # the mounts when update_provider() adds a new secret version, so key
+    # rotations reach warm instances without a redeploy. Versions omitted ->
+    # latest; applybot.llm.client reads <mount_path>/latest.
+    dynamic "secret_volumes" {
+      for_each = local.llm_secret_ids
+      content {
+        mount_path = "/etc/secrets/${secret_volumes.value}"
+        project_id = var.project_id
+        secret     = secret_volumes.value
+      }
+    }
   }
 
   depends_on = [

--- a/infra/cloud_run.tf
+++ b/infra/cloud_run.tf
@@ -13,17 +13,20 @@ resource "google_project_iam_member" "cloud_run_firestore" {
 # Secret Manager access — scoped per secret, not project-wide.
 #
 # secretAccessor: read access for secrets bound via secret_key_ref (serpapi,
-#   dashboard-totp) and for the per-provider LLM keys read live by
-#   applybot.llm.client's store layer on each cache miss.
+#   dashboard-totp) and for the per-provider LLM keys mounted as volumes and
+#   read by applybot.llm.client on each completion.
 resource "google_secret_manager_secret_iam_member" "cloud_run_secret_accessor" {
-  for_each = toset([
-    google_secret_manager_secret.serpapi_key.id,
-    google_secret_manager_secret.dashboard_totp_secret.id,
-    google_secret_manager_secret.llm_provider_key["openai"].id,
-    google_secret_manager_secret.llm_provider_key["anthropic"].id,
-    google_secret_manager_secret.llm_provider_key["gemini"].id,
-    google_secret_manager_secret.llm_provider_key["glm"].id,
-  ])
+  # Keyed by static names (not secret `.id`s) because the per-provider
+  # secrets do not exist until the first apply, and a for_each set cannot
+  # contain values that are only known after apply.
+  for_each = {
+    serpapi   = google_secret_manager_secret.serpapi_key.id
+    totp      = google_secret_manager_secret.dashboard_totp_secret.id
+    openai    = google_secret_manager_secret.llm_provider_key["openai"].id
+    anthropic = google_secret_manager_secret.llm_provider_key["anthropic"].id
+    gemini    = google_secret_manager_secret.llm_provider_key["gemini"].id
+    glm       = google_secret_manager_secret.llm_provider_key["glm"].id
+  }
   secret_id = each.value
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.cloud_run.email}"
@@ -68,6 +71,19 @@ resource "google_cloud_run_v2_service" "applybot" {
 
       ports {
         container_port = 8000
+      }
+
+      # Provider API keys: volume-mounted (not env-bound) so key rotations
+      # written to Secret Manager by update_provider() reach this service
+      # without a new revision -- the platform refreshes the mounts. Each
+      # secret mounts as a directory of version files incl. a `latest` entry,
+      # which is what applybot.llm.client reads.
+      dynamic "volume_mounts" {
+        for_each = local.llm_secret_ids
+        content {
+          name       = volume_mounts.value
+          mount_path = "/etc/secrets/${volume_mounts.value}"
+        }
       }
 
       env {
@@ -132,6 +148,18 @@ resource "google_cloud_run_v2_service" "applybot" {
         limits = {
           cpu    = "1"
           memory = "512Mi"
+        }
+      }
+    }
+
+    # One secret volume per provider key; no version items pinned, so the
+    # mount materializes every version plus `latest` and follows new versions.
+    dynamic "volumes" {
+      for_each = local.llm_secret_ids
+      content {
+        name = volumes.value
+        secret {
+          secret = google_secret_manager_secret.llm_provider_key[volumes.key].id
         }
       }
     }

--- a/infra/secrets.tf
+++ b/infra/secrets.tf
@@ -40,6 +40,12 @@ locals {
   # Provider slugs must match applybot.llm.providers.LLMProvider;
   # secret ids follow the "<slug>-api-key" convention.
   llm_providers = toset(["openai", "anthropic", "gemini", "glm"])
+
+  # Secret id per slug (static strings): used by the IAM grants and the volume
+  # mounts in cloud_run.tf / cloud_functions.tf, whose for_each keys must be
+  # known at plan time -- the secrets' `.id`s are not, until the first apply
+  # creates them.
+  llm_secret_ids = { for slug in local.llm_providers : slug => "${slug}-api-key" }
 }
 
 resource "google_secret_manager_secret" "llm_provider_key" {

--- a/src/applybot/dashboard/README.md
+++ b/src/applybot/dashboard/README.md
@@ -143,14 +143,19 @@ Place your GCP service-account JSON at the repo root as `service-account.json`
 The dashboard is the surface where users update LLM provider keys and the
 default model on the fly (`applybot.llm.client.update_provider` /
 `delete_provider` / `set_default_model`). Those calls write to GCP Secret
-Manager (keys) and Firestore (`config/llm.default_model`); the store layer's
-TTL cache propagates changes across services within seconds.
+Manager (keys) and Firestore (`config/llm.default_model`). Key propagation is
+via **Secret Manager volume mounts** (version `latest`): runtimes read
+`/etc/secrets/<secret_id>` on each completion, and the platform refreshes the
+mounted file when a new version is added — no restart or redeploy needed
+(typically within minutes). The writing process uses the new key immediately
+via an in-process override.
 
-**Infra wiring (done):** the Cloud Run service account has scoped
+**Infra wiring (IAM done, mounts pending):** the Cloud Run service account has scoped
 `roles/secretmanager.secretAccessor` (read) and `roles/secretmanager.secretVersionAdder`
 (write) on the per-provider secrets (`openai-api-key`, `anthropic-api-key`,
-`gemini-api-key`, `glm-api-key`); LLM keys are no longer bound via `secret_key_ref` env vars
-(those resolve only at cold-start). See `infra/cloud_run.tf` / `infra/secrets.tf`.
+`gemini-api-key`, `glm-api-key`). The volume mounts themselves are being added on the
+`sal/rework_llm_api_key_caching` branch — see `infra/cloud_run.tf` /
+`infra/cloud_functions.tf` / `infra/secrets.tf`.
 
 **TODO (code):** expose dashboard endpoints that call `update_provider` /
 `delete_provider` / `set_default_model` behind the existing TOTP auth. The

--- a/src/applybot/dashboard/README.md
+++ b/src/applybot/dashboard/README.md
@@ -144,18 +144,18 @@ The dashboard is the surface where users update LLM provider keys and the
 default model on the fly (`applybot.llm.client.update_provider` /
 `delete_provider` / `set_default_model`). Those calls write to GCP Secret
 Manager (keys) and Firestore (`config/llm.default_model`). Key propagation is
-via **Secret Manager volume mounts** (version `latest`): runtimes read
-`/etc/secrets/<secret_id>` on each completion, and the platform refreshes the
-mounted file when a new version is added — no restart or redeploy needed
-(typically within minutes). The writing process uses the new key immediately
-via an in-process override.
+via **Secret Manager volume mounts**: runtimes read
+`/etc/secrets/<secret_id>/latest` on each completion, and the platform
+refreshes the mounted file when a new version is added — no restart or
+redeploy needed (typically within minutes). The writing process uses the new
+key immediately via an in-process override.
 
-**Infra wiring (IAM done, mounts pending):** the Cloud Run service account has scoped
+**Infra wiring (done):** the Cloud Run service account has scoped
 `roles/secretmanager.secretAccessor` (read) and `roles/secretmanager.secretVersionAdder`
 (write) on the per-provider secrets (`openai-api-key`, `anthropic-api-key`,
-`gemini-api-key`, `glm-api-key`). The volume mounts themselves are being added on the
-`sal/rework_llm_api_key_caching` branch — see `infra/cloud_run.tf` /
-`infra/cloud_functions.tf` / `infra/secrets.tf`.
+`gemini-api-key`, `glm-api-key`); the mounts themselves live in
+`infra/cloud_run.tf` / `infra/cloud_functions.tf` (see `infra/secrets.tf` for
+the secret ids).
 
 **TODO (code):** expose dashboard endpoints that call `update_provider` /
 `delete_provider` / `set_default_model` behind the existing TOTP auth. The

--- a/src/applybot/llm/README.md
+++ b/src/applybot/llm/README.md
@@ -20,11 +20,12 @@ set of providers itself is a code edit in `providers.py`). There is deliberately
 fresh on each access.
 
 - **API keys** live in **GCP Secret Manager** (one secret per provider) and are delivered
-  to every runtime as **volume-mounted files** (`/etc/secrets/<secret_id>`, version
-  `latest`). The platform refreshes mounted secret files automatically when a new version
-  is added — no restart, no new revision — so a key rotated from the dashboard reaches all
-  services within minutes. `client.py` re-reads the file on each completion (a small-file
-  read costs microseconds), so there is **no key cache and no env-var write-back**.
+  to every runtime as **volume mounts**: each secret appears as a directory of version
+  files with a `latest` entry (`/etc/secrets/<secret_id>/latest`), which the platform
+  refreshes automatically when a new version is added — no restart, no new revision —
+  so a key rotated from the dashboard reaches all services within minutes.
+  `client.py` re-reads the `latest` file on each completion (a small-file read costs
+  microseconds), so there is **no key cache and no env-var write-back**.
 - **Default model** lives in a **Firestore** document (`config/llm` → `default_model`)
   (CRUD via the `models` component) behind a short-TTL in-process cache. Model names are
   not secret, so Firestore — not Secret Manager — is the right store.
@@ -66,14 +67,14 @@ write APIs yet — see the TODO in `dashboard/README.md`.
     Adds a new GCP Secret Manager version for the provider's secret and records an
     in-process override (immediate effect in the writing process). Other services pick
     the new key up when the platform refreshes their volume mount (typically within
-    minutes). Locally (no `GCP_PROJECT_ID`) it just sets the env-var fallback.
+    minutes). Locally (no `GCP_PROJECT_ID`) it records the override only.
 
 * Delete provider
     ```python
     def delete_provider(provider: LLMProvider | str) -> None
     ```
-    Adds a blank secret version (mounts refresh to empty) and clears the in-process
-    override / env-var fallback.
+    Adds a blank secret version (mounts refresh to empty) and blanks the in-process
+    override.
 
 * Get default model
     ```python
@@ -111,7 +112,7 @@ write APIs yet — see the TODO in `dashboard/README.md`.
 
 | Env var | Purpose |
 |---|---|
-| `LLM_SECRETS_DIR` | `/etc/secrets` — directory where provider key secrets are volume-mounted; point it at a local dir in tests to exercise the mount path |
+| `LLM_SECRETS_DIR` | `/etc/secrets` — directory where provider key secrets are volume-mounted (each secret is a subdirectory with a `latest` file); point it at a local dir in tests to exercise the mount path |
 | `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `ZAI_API_KEY` | local-dev/tests fallback when the mount is absent; not provisioned on GCP |
 | `LLM_MODEL_DEFAULT` | optional fallback default model when the Firestore `config/llm` doc is absent or unreadable; not provisioned by Terraform (Firestore is the source of truth) |
 | `LLM_MAX_RETRIES` | `3` — litellm retries on transient provider failures |
@@ -131,11 +132,12 @@ so a key changed via `update_provider` takes effect on the very next completion.
 
 ## Infra
 
-Provider secrets are mounted (version `latest`) at `/etc/secrets/<secret_id>` in both the
-Cloud Run service (`volumes` / `volume_mounts` in `infra/cloud_run.tf`) and the discovery
-Cloud Function (`secret_volumes` in `infra/cloud_functions.tf`), so every runtime needs
-`roles/secretmanager.secretAccessor` on the per-provider secrets (scoped, not
-project-wide).
+Provider secrets are mounted in both the Cloud Run service (`volumes` / `volume_mounts`
+in `infra/cloud_run.tf`) and the discovery Cloud Function (`secret_volumes` in
+`infra/cloud_functions.tf`), each at `/etc/secrets/<secret_id>` with no version pinned —
+the mount materializes every version plus a `latest` entry, which is what the client
+reads. Every runtime needs `roles/secretmanager.secretAccessor` on the per-provider
+secrets (scoped, not project-wide).
 
 `update_provider` / `delete_provider` / `set_default_model` write to GCP Secret Manager
 and Firestore, so the service they run in needs:

--- a/src/applybot/llm/README.md
+++ b/src/applybot/llm/README.md
@@ -5,32 +5,40 @@ so swapping the underlying model is a config change, not a code change — no ve
 
 ## Files
 - **providers.py** — `LLMProvider` enum, per-provider metadata, and model-prefix routing (leaf: no runtime state, easy to extend)
-- **_backends.py** — GCP I/O shims: Secret Manager (API keys)
-- **client.py** — the public API: TTL caches, runtime-mutable provider/model stores, and `complete()` (no singleton, no `config.py`)
+- **_backends.py** — GCP Secret Manager write shims (new secret versions on key update/delete); reads happen via the platform volume mount, not the API
+- **client.py** — the public API: mounted-file key lookup, Firestore-backed default-model store (TTL-cached), and `complete()` (no singleton, no `config.py`)
 
 ## Design: runtime-mutable config
+
+> **Status:** target spec for the `sal/rework_llm_api_key_caching` rework (docs-first
+> commit; code and Terraform changes follow on this branch). The PR description on that
+> branch covers the migration plan and the stale-key bug in the previous design.
 
 Provider API keys and the default model are **mutable while the app is deployed** (the
 set of providers itself is a code edit in `providers.py`). There is deliberately no
 `config.py` / settings object — these values change at runtime, so every value is read
-fresh from the environment or its backing store on each access.
+fresh on each access.
 
-- **API keys** live in **GCP Secret Manager** (one secret per provider).
+- **API keys** live in **GCP Secret Manager** (one secret per provider) and are delivered
+  to every runtime as **volume-mounted files** (`/etc/secrets/<secret_id>`, version
+  `latest`). The platform refreshes mounted secret files automatically when a new version
+  is added — no restart, no new revision — so a key rotated from the dashboard reaches all
+  services within minutes. `client.py` re-reads the file on each completion (a small-file
+  read costs microseconds), so there is **no key cache and no env-var write-back**.
 - **Default model** lives in a **Firestore** document (`config/llm` → `default_model`)
-  (CRUD via the `models` component). Model names are not secret, so Firestore —
-  not Secret Manager — is the right store.
+  (CRUD via the `models` component) behind a short-TTL in-process cache. Model names are
+  not secret, so Firestore — not Secret Manager — is the right store.
 
-Both are read through a short-TTL in-process cache (~30 s), so every service that imports
-this module picks up a change within seconds without a redeploy. Writes
-(`update_provider` / `delete_provider` / `set_default_model`) write through to the backing
-store *and* update the cache + env var for immediate local effect.
+Writes (`update_provider` / `delete_provider` / `set_default_model`) write through to the
+backing store *and* record an in-process override, so the writing process (the dashboard)
+uses the new value immediately instead of waiting for the mount to refresh.
 
-> **Cross-service note:** Cloud Run/Functions resolve `secret_key_ref` env vars at instance
-> cold-start, not per call. Because this module fetches keys/model from the backing store on
-> each (cached) access rather than relying on those bound env vars, changes propagate to
-> already-warm instances of every service that imports it (the dashboard and the Cloud
-> Functions both do). The remaining gap is administrative, not infrastructural: no dashboard
-> endpoints call the write APIs yet — see the TODO in `dashboard/README.md`.
+Key lookup order: in-process override → mounted file (`LLM_SECRETS_DIR`, default
+`/etc/secrets`) → provider env var. The env var exists as the **local-dev/tests
+fallback** (no mount on a laptop); it is not provisioned on GCP.
+
+The remaining gap is administrative, not infrastructural: no dashboard endpoints call the
+write APIs yet — see the TODO in `dashboard/README.md`.
 
 ## Public API
 
@@ -53,16 +61,19 @@ store *and* update the cache + env var for immediate local effect.
 
 * Update provider
     ```python
-    def update_provider(provider: LLMProvider | str, api_key: str) -> None:
+    def update_provider(provider: LLMProvider | str, api_key: str) -> None
     ```
-    Sets the API key for that provider as an env variable (immediate local effect) and
-    writes it to GCP Secret Manager so other services pick it up within the cache TTL.
+    Adds a new GCP Secret Manager version for the provider's secret and records an
+    in-process override (immediate effect in the writing process). Other services pick
+    the new key up when the platform refreshes their volume mount (typically within
+    minutes). Locally (no `GCP_PROJECT_ID`) it just sets the env-var fallback.
 
 * Delete provider
     ```python
-    def delete_provider(provider: LLMProvider | str) -> None:
+    def delete_provider(provider: LLMProvider | str) -> None
     ```
-    Clears the env variable and writes a blank version to the GCP secret.
+    Adds a blank secret version (mounts refresh to empty) and clears the in-process
+    override / env-var fallback.
 
 * Get default model
     ```python
@@ -100,13 +111,15 @@ store *and* update the cache + env var for immediate local effect.
 
 | Env var | Purpose |
 |---|---|
+| `LLM_SECRETS_DIR` | `/etc/secrets` — directory where provider key secrets are volume-mounted; point it at a local dir in tests to exercise the mount path |
+| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `ZAI_API_KEY` | local-dev/tests fallback when the mount is absent; not provisioned on GCP |
 | `LLM_MODEL_DEFAULT` | optional fallback default model when the Firestore `config/llm` doc is absent or unreadable; not provisioned by Terraform (Firestore is the source of truth) |
 | `LLM_MAX_RETRIES` | `3` — litellm retries on transient provider failures |
-| `GCP_PROJECT_ID` | when set, keys/models are read from & written to Secret Manager / Firestore; when unset, the module runs in env-only mode (local dev/tests) |
+| `GCP_PROJECT_ID` | when set, key writes go to Secret Manager and the default model is read from/written to Firestore; when unset, the module runs in env-only mode (local dev/tests) |
 
 The provider is selected by the model string prefix (litellm convention):
 
-| Prefix / example | Provider | API key env var | Secret id |
+| Prefix / example | Provider | Local-dev env var | Secret id (= mount file name) |
 |---|---|---|---|
 | `gpt-4o`, `gpt-4o-mini` | OpenAI | `OPENAI_API_KEY` | `openai-api-key` |
 | `claude-3-5-sonnet-20241022` | Anthropic | `ANTHROPIC_API_KEY` | `anthropic-api-key` |
@@ -118,12 +131,18 @@ so a key changed via `update_provider` takes effect on the very next completion.
 
 ## Infra
 
+Provider secrets are mounted (version `latest`) at `/etc/secrets/<secret_id>` in both the
+Cloud Run service (`volumes` / `volume_mounts` in `infra/cloud_run.tf`) and the discovery
+Cloud Function (`secret_volumes` in `infra/cloud_functions.tf`), so every runtime needs
+`roles/secretmanager.secretAccessor` on the per-provider secrets (scoped, not
+project-wide).
+
 `update_provider` / `delete_provider` / `set_default_model` write to GCP Secret Manager
 and Firestore, so the service they run in needs:
 - `roles/secretmanager.secretVersionAdder` on the per-provider secrets (scoped, not project-wide),
 - Firestore write access.
 
-Reads need `roles/secretmanager.secretAccessor`. See `infra/secrets.tf` and `infra/cloud_run.tf`.
+See `infra/secrets.tf`, `infra/cloud_run.tf`, `infra/cloud_functions.tf`.
 
 ## Boundaries
 

--- a/src/applybot/llm/_backends.py
+++ b/src/applybot/llm/_backends.py
@@ -1,7 +1,9 @@
-"""GCP Secret Manager shims for the LLM client.
+"""GCP Secret Manager write shims for the LLM client.
 
-Secret Manager holds the provider API keys; these are pure I/O shims over the
-GCP SDKs -- all caching and policy lives in :mod:`applybot.llm.client`. The
+Secret Manager holds the provider API keys. Reads do not go through these
+shims: every runtime receives the keys as volume-mounted files (refreshed by
+the platform when a new version is added), and only ``update_provider`` /
+``delete_provider`` write new secret versions via :func:`write_secret`. The
 default model lives in the Firestore ``config/llm`` document, accessed via
 :mod:`applybot.models.config` (the models component owns all Firestore CRUD).
 Outside GCP (no ``GCP_PROJECT_ID``) the client does not engage these helpers,
@@ -10,7 +12,6 @@ so local dev/tests run env-only.
 
 from __future__ import annotations
 
-import logging
 import os
 from functools import lru_cache
 from typing import Any
@@ -18,8 +19,6 @@ from typing import Any
 from google.api_core import exceptions
 
 from .providers import LLMProvider
-
-logger = logging.getLogger(__name__)
 
 
 def project_id() -> str | None:
@@ -29,7 +28,7 @@ def project_id() -> str | None:
 
 
 # ---------------------------------------------------------------------------
-# Secret Manager (API keys)
+# Secret Manager (API keys) -- write path only; reads use the volume mount
 # ---------------------------------------------------------------------------
 
 
@@ -58,23 +57,6 @@ def ensure_secret_exists(provider: LLMProvider) -> None:
                 "secret": {"replication": {"automatic": {}}},
             }
         )
-
-
-def read_secret(provider: LLMProvider) -> str:
-    """Read the latest secret version, returning ``""`` if absent/empty."""
-    client = secret_client()
-    try:
-        resp = client.access_secret_version(
-            request={"name": f"{_secret_name(provider)}/versions/latest"}
-        )
-        return str(resp.payload.data.decode("utf-8"))
-    except exceptions.NotFound:
-        return ""
-    except Exception:  # noqa: BLE001 - degrade to env-only on any SM failure
-        logger.warning(
-            "Secret Manager read failed for %s; falling back to env", provider
-        )
-        return os.environ.get(provider.env_var, "")
 
 
 def write_secret(provider: LLMProvider, value: str) -> None:

--- a/src/applybot/llm/client.py
+++ b/src/applybot/llm/client.py
@@ -8,12 +8,13 @@ code change.
 
 Provider API keys and the default model are **mutable at runtime** -- callers
 may update or delete providers and change the default model while the app is
-deployed. Keys live in GCP Secret Manager (I/O shims in
-:mod:`applybot.llm._backends`); the default model lives in a Firestore
+deployed. Keys live in GCP Secret Manager and are delivered to every runtime
+as volume-mounted files (``<LLM_SECRETS_DIR>/<secret_id>/latest``, refreshed
+by the platform when a new version is added), so this module simply re-reads
+the file on each access -- there is no key cache. Writes go through the I/O
+shims in :mod:`applybot.llm._backends`. The default model lives in a Firestore
 ``config/llm`` document accessed via :mod:`applybot.models.config` (the models
-component owns all Firestore CRUD). This module owns the short-TTL in-process
-caches (:class:`_TTLCache` instances, not ``functools.lru_cache``) so every
-service importing it picks up changes within seconds without a redeploy.
+component owns all Firestore CRUD) behind a short-TTL cache.
 
 There is deliberately no ``config.py`` / settings object: every value is read
 fresh from the environment or the backing store on each access, because these
@@ -29,6 +30,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+from pathlib import Path
 from typing import Any, overload
 
 import litellm
@@ -47,9 +49,9 @@ from .providers import (
 logger = logging.getLogger(__name__)
 
 
-# How long a cached value (key / model) is trusted before re-fetching the
-# backing store. Keeps per-completion latency low while still propagating
-# updates across services within seconds.
+# How long the cached default model is trusted before re-fetching Firestore.
+# Keeps per-completion latency low while still propagating updates across
+# services quickly.
 _CACHE_TTL_SECONDS = 30.0
 
 _DEFAULT_MODEL_DOC = "llm"
@@ -106,30 +108,59 @@ class _TTLCache[K, V]:
 
 
 # ---------------------------------------------------------------------------
-# Key store: env var (in-process) + Secret Manager (cross-service), TTL cached
+# Key lookup: in-process override → mounted secret file → env var
 # ---------------------------------------------------------------------------
 
-_key_cache = _TTLCache[LLMProvider, str]()
+# Directory where provider key secrets are volume-mounted (one subdirectory
+# per secret, holding version files including a `latest` entry). Overridable
+# so tests can point it at a local directory.
+_SECRETS_DIR_ENV = "LLM_SECRETS_DIR"
+_DEFAULT_SECRETS_DIR = "/etc/secrets"
+
+# Keys set via update_provider()/delete_provider() in this process. They take
+# effect immediately, without waiting for the platform to refresh the volume
+# mount (which typically takes minutes).
+_key_overrides: dict[LLMProvider, str] = {}
+
+
+def _mounted_key(provider: LLMProvider) -> str:
+    """Read the provider's key from the volume-mounted secret, or ``""``.
+
+    GCP mounts each provider secret as a directory of version files with a
+    ``latest`` entry and refreshes it when a new version is added, so this
+    read always returns the current key. Whitespace is stripped because
+    versions seeded outside Terraform can carry a trailing newline.
+    """
+    path = (
+        Path(os.environ.get(_SECRETS_DIR_ENV, _DEFAULT_SECRETS_DIR))
+        / provider.secret_id
+        / "latest"
+    )
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return ""
+    except OSError:
+        logger.warning("Failed to read mounted secret %s", path)
+        return ""
 
 
 def _get_provider_key(provider: LLMProvider) -> str:
     """Return the API key for ``provider``.
 
-    Serves from the TTL cache, else from the env var, else from Secret Manager
-    (which populates both the cache and the env var so litellm can also find it).
+    Order: in-process override (set by update/delete in this process), the
+    volume-mounted secret file, then the provider env var (local dev/tests,
+    where no mount exists).
     """
-    cached = _key_cache.get(provider)
-    if cached is not None:
-        return cached
+    override = _key_overrides.get(provider)
+    if override is not None:
+        return override
 
-    key = os.environ.get(provider.env_var, "")
-    if not key and _backends.project_id():
-        key = _backends.read_secret(provider)
-        if key:
-            os.environ[provider.env_var] = key
+    mounted = _mounted_key(provider)
+    if mounted:
+        return mounted
 
-    _key_cache.set(provider, key)
-    return key
+    return os.environ.get(provider.env_var, "")
 
 
 def get_configured_providers() -> list[LLMProvider]:
@@ -140,26 +171,25 @@ def get_configured_providers() -> list[LLMProvider]:
 def update_provider(provider: LLMProvider | str, api_key: str) -> None:
     """Set ``provider``'s API key.
 
-    Writes the key to the process env var (immediate effect locally) and to
-    GCP Secret Manager so other services pick it up within the cache TTL.
+    Adds a new version in GCP Secret Manager -- other services pick it up when
+    the platform refreshes their volume mount -- and records an in-process
+    override so this process uses the new key immediately.
     """
     if not isinstance(provider, LLMProvider):
         provider = LLMProvider(provider)
-    os.environ[provider.env_var] = api_key
-    _key_cache.set(provider, api_key)
+    _key_overrides[provider] = api_key
     if _backends.project_id():
         try:
             _backends.write_secret(provider, api_key)
-        except Exception:  # noqa: BLE001 - env is set; SM failure is non-fatal
+        except Exception:  # noqa: BLE001 - override is set; SM failure is non-fatal
             logger.exception("Failed to write %s key to Secret Manager", provider)
 
 
 def delete_provider(provider: LLMProvider | str) -> None:
-    """Delete ``provider``'s key: clear the env var and set the secret to blank."""
+    """Delete ``provider``'s key: blank secret version + blank in-process override."""
     if not isinstance(provider, LLMProvider):
         provider = LLMProvider(provider)
-    os.environ.pop(provider.env_var, None)
-    _key_cache.pop(provider)
+    _key_overrides[provider] = ""
     if _backends.project_id():
         try:
             _backends.write_secret(provider, "")

--- a/src/applybot/llm/tests/test_client.py
+++ b/src/applybot/llm/tests/test_client.py
@@ -1,13 +1,16 @@
 """Tests for the litellm-backed LLM client.
 
 litellm itself is mocked, and GCP is disabled (no ``GCP_PROJECT_ID``) so the
-store runs in env-only mode. These tests assert the client's contract: model
-selection, message building, response parsing, provider inference, and the
+client runs in env-only mode. These tests assert the client's contract: model
+selection, message building, response parsing, provider inference, key
+lookup (in-process override → mounted secret file → env var), and the
 runtime-mutable provider/default-model state -- all without network calls.
 """
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -44,15 +47,16 @@ def _fake_response(content: str | None) -> Any:
 
 @pytest.fixture(autouse=True)
 def _env_only(monkeypatch: pytest.MonkeyPatch) -> Any:
-    """Run in env-only mode (no GCP) and isolate caches + env vars per test."""
+    """Run in env-only mode (no GCP, no mount) and isolate state per test."""
     monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
+    monkeypatch.delenv("LLM_SECRETS_DIR", raising=False)
     for p in LLMProvider:
         monkeypatch.delenv(p.env_var, raising=False)
     monkeypatch.delenv("LLM_MODEL_DEFAULT", raising=False)
-    llm_client._key_cache.clear()
+    llm_client._key_overrides.clear()
     llm_client._model_cache.clear()
     yield
-    llm_client._key_cache.clear()
+    llm_client._key_overrides.clear()
     llm_client._model_cache.clear()
 
 
@@ -199,6 +203,97 @@ class TestProviderStore:
             LLMProvider.OPENAI,
             LLMProvider.GEMINI,
         }
+
+    @patch("applybot.llm.client._backends.write_secret")
+    def test_update_writes_secret_version(
+        self, mock_write: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GCP_PROJECT_ID", "proj")
+
+        update_provider(LLMProvider.OPENAI, "sk-test")
+
+        mock_write.assert_called_once_with(LLMProvider.OPENAI, "sk-test")
+        assert llm_client._key_overrides[LLMProvider.OPENAI] == "sk-test"
+        assert "OPENAI_API_KEY" not in os.environ  # no env-var write-back
+
+    @patch("applybot.llm.client._backends.write_secret")
+    def test_delete_writes_blank_version(
+        self, mock_write: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GCP_PROJECT_ID", "proj")
+        update_provider(LLMProvider.OPENAI, "sk-test")
+
+        delete_provider(LLMProvider.OPENAI)
+
+        mock_write.assert_called_with(LLMProvider.OPENAI, "")
+        assert get_configured_providers() == []
+
+
+class TestKeyLookup:
+    """Key resolution order: in-process override → mounted file → env var."""
+
+    @staticmethod
+    def _mount(tmp_path: Path, provider: LLMProvider, value: str) -> None:
+        """Write a mounted-secret lookalike: ``<dir>/<secret_id>/latest``."""
+        secret_dir = tmp_path / provider.secret_id
+        secret_dir.mkdir()
+        (secret_dir / "latest").write_text(value, encoding="utf-8")
+
+    def test_mounted_file_beats_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LLM_SECRETS_DIR", str(tmp_path))
+        monkeypatch.setenv(LLMProvider.OPENAI.env_var, "sk-env")
+        self._mount(tmp_path, LLMProvider.OPENAI, "sk-mounted\n")
+
+        assert llm_client._get_provider_key(LLMProvider.OPENAI) == "sk-mounted"
+
+    def test_env_var_when_no_mount(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(LLMProvider.OPENAI.env_var, "sk-env")
+
+        assert llm_client._get_provider_key(LLMProvider.OPENAI) == "sk-env"
+
+    def test_override_beats_mount_and_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LLM_SECRETS_DIR", str(tmp_path))
+        monkeypatch.setenv(LLMProvider.OPENAI.env_var, "sk-env")
+        self._mount(tmp_path, LLMProvider.OPENAI, "sk-mounted")
+        llm_client._key_overrides[LLMProvider.OPENAI] = "sk-new"
+
+        assert llm_client._get_provider_key(LLMProvider.OPENAI) == "sk-new"
+
+    def test_mount_refresh_seen_without_restart(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A new secret version must be visible on the next access in the same
+        process -- the propagation the old TTL/env-var design broke."""
+        monkeypatch.setenv("LLM_SECRETS_DIR", str(tmp_path))
+        self._mount(tmp_path, LLMProvider.OPENAI, "sk-v1")
+        assert llm_client._get_provider_key(LLMProvider.OPENAI) == "sk-v1"
+
+        (tmp_path / LLMProvider.OPENAI.secret_id / "latest").write_text(
+            "sk-v2", encoding="utf-8"
+        )
+
+        assert llm_client._get_provider_key(LLMProvider.OPENAI) == "sk-v2"
+
+    @patch("applybot.llm.client.litellm")
+    def test_complete_uses_mounted_key(
+        self,
+        mock_litellm: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_litellm.completion.return_value = _fake_response("ok")
+        monkeypatch.setenv("LLM_SECRETS_DIR", str(tmp_path))
+        monkeypatch.setenv("LLM_MODEL_DEFAULT", "gpt-4o-mini")
+        self._mount(tmp_path, LLMProvider.OPENAI, "sk-mounted")
+
+        complete(None, None, "hi")
+
+        _, kwargs = mock_litellm.completion.call_args
+        assert kwargs["api_key"] == "sk-mounted"
 
 
 class TestDefaultModel:


### PR DESCRIPTION
## Problem

`_get_provider_key()` (`src/applybot/llm/client.py`) resolves keys as: TTL cache → **env var** → Secret Manager, and a successful Secret Manager read is written back into the process env var. That write-back defeats the re-check:

- After the first fetch, the env var is populated, so every later cache expiry short-circuits on the stale env var — **Secret Manager is never re-read**.
- Concretely: a key rotated while a Cloud Function instance is warm never reaches that instance; only cold starts pick up the new value (the process where `update_provider` was called is fine, since it writes through its own cache).
- The module README's claim that changes propagate "within seconds without a redeploy" does not match what the code actually does.
- Tests don't catch this because they run env-only (`GCP_PROJECT_ID` unset), so the Secret Manager path is never exercised with a pre-populated env var.

The design also carries significant complexity for what it buys: a hand-rolled `_TTLCache` for keys, an env-var fallback layer, env-var write-back (justified as "so litellm can find it" — vestigial, since `complete()` passes `api_key` explicitly), and a Secret Manager read client.

## Solution: Secret Manager volume mounts

Provider keys are delivered as **volume-mounted secrets** instead of API reads on each cache miss:

- Both runtimes (Cloud Run dashboard, discovery Cloud Function) mount each provider secret at `/etc/secrets/<secret_id>` with no version pinned — the mount materializes every version plus a `latest` entry, and the platform **refreshes it when a new version is added** — no restart, no new revision, no redeploy permissions.
- `client.py` reads `<LLM_SECRETS_DIR>/<secret_id>/latest` on each completion (a small-file read costs microseconds), so **the key TTL cache, the env-var write-back, and the Secret Manager read client are gone**.
- `update_provider()` / `delete_provider()` keep adding new secret versions (`secretVersionAdder` IAM already in place) and record an **in-process override** so the writing process (the dashboard) uses the new key immediately instead of waiting for the mount refresh.
- Key lookup order: in-process override → mounted file (`LLM_SECRETS_DIR`, default `/etc/secrets`) → provider env var. The env var remains as the **local-dev/tests fallback only**.
- The default model is unaffected: it's not a secret, stays in Firestore `config/llm` behind its TTL cache.

Rejected alternative: bind keys as regular env vars and have the dashboard force a service reload on change. There is no restart API — it requires revision-forcing patches (IAM escalation to `run.services.update`/redeploy power for the dashboard SA, Terraform drift, cold starts, waiting out in-flight requests) to achieve propagation that is no faster than the mount refresh.

## Work items

- [x] `infra/cloud_run.tf` — `volumes` (`secret`, no version items → all versions + `latest`) + `volume_mounts` for the 4 provider secrets at `/etc/secrets/<secret_id>`; scoped `secretAccessor`/`secretVersionAdder` IAM kept.
- [x] `infra/cloud_functions.tf` — `secret_volumes` for the same 4 secrets on the discovery function (versions omitted → latest).
- [x] `src/applybot/llm/client.py` — `_get_provider_key()` reworked to override → mounted file → env; `_key_cache` and env write-back deleted; `update_provider`/`delete_provider` write secret versions + manage the in-process override.
- [x] `src/applybot/llm/_backends.py` — `read_secret()` deleted; module is now write-only shims (`ensure_secret_exists` / `write_secret`).
- [x] `src/applybot/llm/tests/test_client.py` — `TestKeyLookup` covers the resolution order, the trailing-newline strip, and the regression case (mount refresh seen without restart); GCP write-path tests via mocked `_backends.write_secret`; env-only tests kept via the fallback.
- [x] Docs: `src/applybot/llm/README.md` + `src/applybot/dashboard/README.md` updated to the implemented layout.

## Vestigial code removed (old approach)

- `_key_cache` (the `_TTLCache` instance for keys) and the key-path TTL caching. `_TTLCache` itself stays — the default-model cache still uses it.
- Env write-back in `_get_provider_key()` (`os.environ[provider.env_var] = key`).
- Env-var mutation in `update_provider()` / `delete_provider()` (`os.environ[provider.env_var] = api_key` / `os.environ.pop(...)`): they now record the in-process override only — the override is the sole immediate-effect mechanism, even in local dev.
- `_backends.read_secret()` and its env-fallback branch.
- The "so litellm can also find it" rationale — `complete()` passes `api_key` explicitly, no global litellm state is involved.

## Verification

- `pytest src/applybot/llm/tests/` — 29 passed. Full suite: 89 passed, 84 skipped; the 4 collection errors (`tests/test_tracking.py`, `discovery/tests/*` on `applybot.config`) pre-exist on main.
- `ruff check`, `ruff format`, `black`, and strict `mypy` clean on `src/applybot/llm/` (repo-wide ruff findings in `models/`/`storage.py` also pre-exist on main).
- `terraform fmt` / `validate` clean; `terraform plan` succeeds and the planned values show all 4 mounts on both the Cloud Run service (`volume_mounts` + `volumes`) and the discovery function (`secret_volumes`).

## Extra fix included

Planning this branch exposed a **pre-existing blocker on main**: `google_secret_manager_secret_iam_member.cloud_run_secret_accessor` built `for_each` from `toset([...secret .id...])`, and the per-provider secrets don't exist in the live project yet, so their ids are unknown until apply — every plan/apply of the current main config fails with "for_each set includes values derived from resource attributes". Fixed by keying that for_each with a static map (`infra/secrets.tf` gains a shared `llm_secret_ids` local, also used by the dynamic mount blocks).

## Deploy notes

- The per-provider secrets, their IAM grants, and the mounts are all **created on the first `terraform apply`** of this branch (plan shows them as creates) — the litellm-refactor secrets config was never applied to prod. Append `--tf-apply` to the merge/squash commit message to trigger the Terraform workflow.
- Pre-existing drift visible in the plan, untouched here: `serpapi`/`totp` secret versions show recreate (tfvars differ from state), and two stale IAM members + one Firestore index are pending deletion. Note: one of those deletes is the project-wide `roles/secretmanager.secretAccessor` grant the live service currently relies on (no per-secret members exist in state yet); this apply replaces it with the scoped per-secret members, but Terraform does not guarantee create-before-delete, so the first apply carries a brief window where the SA may lack Secret Manager read access.
- Runtime caveat: mount refresh is platform-paced (typically a few minutes) — fine for rarely-rotated keys; the writing process sees changes immediately via the override.

## Follow-ups (out of scope here)

- Dashboard endpoints behind the existing TOTP auth calling `update_provider` / `delete_provider` / `set_default_model` (existing TODO in `src/applybot/dashboard/README.md`). The client + infra changes on this branch are the prerequisite.

